### PR TITLE
fix a problem that causes a binding not to work with logicalXXX() as a method matcher

### DIFF
--- a/src/Bind.php
+++ b/src/Bind.php
@@ -117,7 +117,7 @@ final class Bind extends ArrayObject implements BindInterface
     {
         $methods = (new ReflectionClass($class))->getMethods(ReflectionMethod::IS_PUBLIC);
         foreach ($methods as $method) {
-            $isMethodMatch = ($methodMatcher($method->name, Matcher::TARGET_METHOD) === true);
+            $isMethodMatch = ($methodMatcher($method, Matcher::TARGET_METHOD) === true);
             if ($isMethodMatch) {
                 $this->bindInterceptors($method->name, $interceptors);
             }

--- a/tests/BindTest.php
+++ b/tests/BindTest.php
@@ -197,4 +197,37 @@ class BindTest extends \PHPUnit_Framework_TestCase
         $this->bind->bind($class, [$pointcut]);
         $this->assertSame(0, (count($this->bind)));
     }
+
+    /**
+     * @return array
+     */
+    public function logicalMethodMatchers()
+    {
+        $matcher = new Matcher(new Reader);
+
+        return [
+            [$matcher->logicalOr($matcher->annotatedWith('Ray\Aop\Annotation\Resource'), $matcher->annotatedWith('Ray\Aop\Annotation\Marker'))],
+            [$matcher->logicalAnd($matcher->annotatedWith('Ray\Aop\Annotation\Marker'), $matcher->startsWith('getDouble'))],
+            [$matcher->logicalXor($matcher->annotatedWith('Ray\Aop\Annotation\Marker'), $matcher->annotatedWith('Ray\Aop\Annotation\Resource'))],
+            [$matcher->logicalNot($matcher->annotatedWith('Ray\Aop\Annotation\Resource'))],
+        ];
+    }
+
+    /**
+     * @param Matchable $logicalMethodMatcher
+     * @dataProvider logicalMethodMatchers
+     */
+    public function testBindByLogicalBindingAsMethodMatcher(Matchable $logicalMethodMatcher)
+    {
+        $matcher = new Matcher(new Reader);
+        $class = 'Ray\Aop\Mock\AnnotateClass';
+        $pointcut = new Pointcut($matcher->any(), $logicalMethodMatcher, $this->interceptors);
+
+        $result = $this->bind->bind($class, [$pointcut]);
+
+        /** @noinspection PhpParamsInspection */
+        list($method, $interceptors) = each($result);
+        $this->assertSame('getDouble', $method);
+        $this->assertSame($this->interceptors, $interceptors);
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | BSD-3-Clause |
| Doc PR | - |

Ray.Di の `AbstractModule::bindInterceptor()` のメソッドマッチャーで `logicalAnd()` を使うと、以下のような例外が発生します。

``` php
$this->bindInterceptor(
    $this->matcher->any(),
    $this->matcher->logicalAnd(
        $this->matcher->annotatedWith('...'),
        $this->matcher->annotatedWith('...')
    ),
    [...]
);
```

``` console
Fatal error: Uncaught exception 'ReflectionException' with message 'Class disableOutput does not exist' in /path/to/project/vendor/ray/aop/src/Matcher.php on line 236

ReflectionException: Class disableOutput does not exist in /path/to/project/vendor/ray/aop/src/Matcher.php on line 236

Call Stack:
    0.0002     249824   1. {main}() /path/to/project/bootstrap/contexts/api.php:0
    0.0071    1052816   2. require('/path/to/project/bootstrap/instance.php') /path/to/project/bootstrap/contexts/api.php:34
    0.0071    1053056   3. BEAR\Package\Bootstrap\Bootstrap::getApp() /path/to/project/bootstrap/instance.php:19
    ...
    0.1938    6353672  32. Ray\Di\AbstractModule->__invoke() /path/to/project/vendor/ray/di/src/Injector.php:211
    0.1938    6354304  33. Ray\Aop\Bind->bind() /path/to/project/vendor/ray/di/src/AbstractModule.php:436
    0.1968    6353048  34. Ray\Aop\Bind->bindPointcut() /path/to/project/vendor/ray/aop/src/Bind.php:40
    0.1968    6353224  35. Ray\Aop\Bind->bindByCallable() /path/to/project/vendor/ray/aop/src/Bind.php:63
    0.1968    6354400  36. Ray\Aop\AbstractMatcher->__invoke() /path/to/project/vendor/ray/aop/src/Bind.php:120
    0.1968    6355488  37. call_user_func_array() /path/to/project/vendor/ray/aop/src/AbstractMatcher.php:70
    0.1968    6356144  38. Ray\Aop\Matcher->isLogicalAnd() /path/to/project/vendor/ray/aop/src/AbstractMatcher.php:70
    0.1968    6356144  39. Ray\Aop\AbstractMatcher->__invoke() /path/to/project/vendor/ray/aop/src/Matcher.php:338
    0.1968    6357448  40. call_user_func_array() /path/to/project/vendor/ray/aop/src/AbstractMatcher.php:70
    0.1968    6357968  41. Ray\Aop\Matcher->isAnnotatedWith() /path/to/project/vendor/ray/aop/src/AbstractMatcher.php:70
    0.1968    6357968  42. Ray\Aop\Matcher->setAnnotations() /path/to/project/vendor/ray/aop/src/Matcher.php:221
    0.1968    6358184  43. ReflectionClass->__construct() /path/to/project/vendor/ray/aop/src/Matcher.php:236
```

調べてみると、`Ray\Aop\Bind::bind()` の第 2 引数で `logicalOr`、`logicalAnd`、`logicalXor`、`logicalNot` のいずれかを使うと、`Ray\Aop\Bind::bindByCallable()` のメソッドマッチャーの呼び出しの第 1 引数にメソッド名が渡され `$methodMatcher($method->name, Matcher::TARGET_METHOD)`、メソッド名をクラス名として `ReflectionClass` オブジェクトを作成するところ `Matcher::setAnnotations()` で上記の例外が発生することがわかりました。

このプルリクエストは上記問題を修正し、`bind()` の第 2 引数で `logicalOr`、`logicalAnd`、`logicalXor`、`logicalNot` を使えるようにします。
