### PR TITLE
fix class match on logical and/or matchers

### DIFF
--- a/src/Matcher/LogicalAndMatcher.php
+++ b/src/Matcher/LogicalAndMatcher.php
@@ -18,7 +18,7 @@ class LogicalAndMatcher extends AbstractMatcher
         $isAnd = true;
         foreach ($arguments as $matcher) {
             /* @var $matcher AbstractMatcher */
-            $isAnd = $isAnd && $matcher->matchesClass($class, []);
+            $isAnd = $isAnd && $matcher->matchesClass($class, $matcher->getArguments());
         }
 
         return $isAnd;

--- a/src/Matcher/LogicalOrMatcher.php
+++ b/src/Matcher/LogicalOrMatcher.php
@@ -17,7 +17,7 @@ class LogicalOrMatcher extends AbstractMatcher
     {
         foreach ($arguments as $matcher) {
             /* @var $matcher AbstractMatcher */
-            $isMatch =  $matcher->matchesClass($class, []);
+            $isMatch =  $matcher->matchesClass($class, $matcher->getArguments());
             if ($isMatch === true) {
                 return true;
             }


### PR DESCRIPTION
- class の match (logicalOr, logicalAnd) で子の matcher の引数が渡されていない不具合の修正。
