### PR TITLE
AbstractAssisted annotation adds method arguments default null

### DIFF
--- a/src/Annotation/AbstractAssisted.php
+++ b/src/Annotation/AbstractAssisted.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * This file is part of the Ray.Aop package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace Ray\Aop\Annotation;
+
+/**
+ * @Annotation
+ * @Target("METHOD")
+ */
+abstract class AbstractAssisted
+{
+    /**
+     * Add null default to listed parameters
+     *
+     * @var array
+     */
+    public $values;
+}

--- a/tests/CodeGenTest.php
+++ b/tests/CodeGenTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Ray\Aop;
+
+namespace Ray\Aop;
+
+use PhpParser\BuilderFactory;
+use PhpParser\Lexer;
+use PhpParser\Parser;
+use PhpParser\PrettyPrinter\Standard;
+
+class CodeGenTest extends \PHPUnit_Framework_TestCase
+{
+    public function testAddNullDefaultWithAssisted()
+    {
+        $codeGen = new CodeGen(new Parser(new Lexer), new BuilderFactory, new Standard);
+        $bind = new Bind;
+        $bind->bindInterceptors('run', []);
+        $code = $codeGen->generate('a', new \ReflectionClass(FakeAssistedConsumer::class), $bind);
+        $expected = 'function run($a, $b = null, $c = null)';
+        $this->assertContains($expected, $code);
+    }
+}

--- a/tests/Fake/FakeAssisted.php
+++ b/tests/Fake/FakeAssisted.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Ray.Aop package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace Ray\Aop;
+use Ray\Aop\Annotation\AbstractAssisted;
+
+/**
+ * @Annotation
+ * @Target("METHOD")
+ */
+final class FakeAssisted extends AbstractAssisted
+{
+    /**
+     * @var array
+     */
+    public $values;
+}

--- a/tests/Fake/FakeAssistedConsumer.php
+++ b/tests/Fake/FakeAssistedConsumer.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Ray\Aop;
+
+use Ray\Aop\FakeAssisted;
+
+class FakeAssistedConsumer
+{
+    /**
+     * @FakeAssisted({"b", "c"})
+     */
+    public function run($a, $b, $c)
+    {
+        return [$a, $b, $c];
+    }
+}


### PR DESCRIPTION
this is for runtime injection as kwon as  @Assisted injection.

final class Assisted extends extends AbstractAssisted

``` php
use Ray\Aop\Annotation\AbstractAssisted;

/**
 * @Annotation
 * @Target("METHOD")
 */
final class FooAssisted extends AbstractAssisted
{
    /**
     * @var array
     */
    public $values;
}

class Foo
{
    /**
     * @FooAssisted({"b", "c"})
     */
    public function run($a, $b, $c)
    {
        return [$a, $b, $c];
    }
```

Ray.Aop compiler convert code as following.

``` php
    /**
     * @FooAssisted({"b", "c"})
     */
    public function run($a, $b = null, $c = null)
    {
        return [$a, $b, $c];
    }
```

This is handy when interceptors provides parameters.
