### PR TITLE
Compiled annotation reader

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -210,8 +210,22 @@ class MyInterceptor implements MethodInterceptor
  * [`$invocation->getMethod()`](https://github.com/ray-di/Ray.Aop/blob/2.x/src/MethodInvocation.php#L29) -  メソッドリフレクションの取得
  * [`$invocation->getThis()`](https://github.com/ray-di/Ray.Aop/blob/2.x/src/Joinpoint.php#L48) - オブジェクトの取得
  * [`$invocation->getArguments()`](https://github.com/ray-di/Ray.Aop/blob/2.x/src/MethodInvocation.php#L29) - 引数の取得
+
+拡張されたリフレクションはアノテーション取得のメソッドを持ちます。
  
+```php
+/** @var $method \Ray\Aop\ReflectionMethod */
+$method = $invocation->getMethod();
+/** @var $class \Ray\Aop\ReflectionClass */
+$class = $invocation->getMethod()->getDeclaringClass();
+```
+
  
+ * [`$method->getAnnotations()`]() - メソッドアノテーションの取得
+ * [`$method->getAnnotation($name)`]() 
+ * [`$class->->getAnnotations()`]() - クラスアノテーションの取得
+ * [`$class->->getAnnotation($name)`]()
+
 ## AOPアライアンス
 
 このメソッドインターセプターのAPIは[AOPアライアンス](http://aopalliance.sourceforge.net/doc/org/aopalliance/intercept/MethodInterceptor.html)の部分実装です。

--- a/README.ja.md
+++ b/README.ja.md
@@ -14,8 +14,7 @@
 
 [MethodInterceptors](https://github.com/ray-di/Ray.Aop/blob/2.x/src/MethodInterceptor.php) はマッチしたメソッドが呼ばれる度に実行されます。呼び出しやメソッド、それらの引き数、インスタンスを調べる事ができます。横断的なロジックと委譲されたメソッドが実行されます。最後に返り値を調べて返します。インターセプターは沢山のメソッドに適用され沢山のコールを受け取るので、実装は効果的で透過的なものになります。
 
-例：平日のメソッドコールを禁止する
---------------------------------
+## 例：平日のメソッドコールを禁止する
 
 メソッドインターセプターがRay.Aopでどのように機能するかを明らかにするために、週末にはピザの注文を禁止するようにしてみましょう。デリバリーは平日だけ受け付ける事にして、ピザの注文を週末には受け付けないようにします！この例はAOPで認証を使用するときにのパターンと構造的に似ています。
 
@@ -96,8 +95,7 @@ try {
 chargeOrder not allowed on weekends!
 ```
 
-メソッド名を指定したマッチ
----------------------------
+## メソッド名を指定したマッチ
 
 ```php
 <?php
@@ -112,8 +110,7 @@ chargeOrder not allowed on weekends!
     }
 ```
 
-独自のマッチャー
----------------
+## 独自のマッチャー
 
 独自のマッチャーを作成することもでます。
 `contains` マッチャーを作成するためには、２つのメソッドを持つクラスを提供する必要があります。
@@ -157,8 +154,7 @@ $bind = (new Bind)->bind(RealBillingService::class, [$pointcut]);
 $billing = (new Compiler($tmpDir))->newInstance(RealBillingService::class, [], $bind);
 ```
 
-優先順位
---------
+## 優先順位
 
 インターセプターの実行順は以下のルールで決定されます。
 
@@ -174,8 +170,7 @@ $billing = (new Compiler($tmpDir))->newInstance(RealBillingService::class, [], $
  */
 ```
 
-制限
-----
+## 制限
 
 この機能の背後ではメソッドのインターセプションを事前にコードを生成する事で可能にしています。Ray.Aopはダイナミックにサブクラスを生成してメソッドをオーバーライドするインターセプターを適用します。
 
@@ -183,21 +178,50 @@ $billing = (new Compiler($tmpDir))->newInstance(RealBillingService::class, [], $
 
  * クラスは *final* ではない
  * メソッドは *public*
- * メソッドは *final* ではない
 
-AOPアライアンス
---------------
+
+## インターセプター
+
+呼び出されたメソッドをそのまま実行するだけのインターセプターは以下のようになります。
+
+```php
+class MyInterceptor implements MethodInterceptor
+{
+    public function invoke(MethodInvocation $invocation)
+    {
+        // メソッド実行前
+        //
+        
+        // メソッド実行
+        $result = invocation->proceed();
+        
+        // メソッド実行後
+        //
+                
+        return $result;
+    }
+}
+```
+
+インターセプターに渡されるメソッド実行(`MethodInvocation`)オブジェクトは以下のメソッドを持ちます。
+
+
+ * [`$invocation->proceed()`](https://github.com/ray-di/Ray.Aop/blob/2.x/src/Joinpoint.php#L39) - メソッド実行
+ * [`$invocation->getMethod()`](https://github.com/ray-di/Ray.Aop/blob/2.x/src/MethodInvocation.php#L29) -  メソッドリフレクションの取得
+ * [`$invocation->getThis()`](https://github.com/ray-di/Ray.Aop/blob/2.x/src/Joinpoint.php#L48) - オブジェクトの取得
+ * [`$invocation->getArguments()`](https://github.com/ray-di/Ray.Aop/blob/2.x/src/MethodInvocation.php#L29) - 引数の取得
+ 
+ 
+## AOPアライアンス
 
 このメソッドインターセプターのAPIは[AOPアライアンス](http://aopalliance.sourceforge.net/doc/org/aopalliance/intercept/MethodInterceptor.html)の部分実装です。
 
-要件
-----
+## 要件
 
 * PHP 5.4+
 * hhvm
 
-インストール
-------------
+## インストール
 
 Ray.Aopの推奨インストール方法は、[Composer](https://github.com/composer/composer)でのインストールです。
 
@@ -206,8 +230,7 @@ Ray.Aopの推奨インストール方法は、[Composer](https://github.com/comp
 $ composer require ray/aop ~2.0
 ```
 
-Ray.Aopのテスト
----------------
+## Ray.Aopのテスト
 
 Ray.Aopをソースからインストールし、ユニットテストとデモを実行するには次のようにします。
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ A [Matcher](https://github.com/ray-di/Ray.Aop/blob/2.x/src/MatcherInterface.php)
 
 [MethodInterceptors](https://github.com/ray-di/Ray.Aop/blob/2.x/src/MethodInterceptor.php) are executed whenever a matching method is invoked. They have the opportunity to inspect the call: the method, its arguments, and the receiving instance. They can perform their cross-cutting logic and then delegate to the underlying method. Finally, they may inspect the return value or exception and return. Since interceptors may be applied to many methods and will receive many calls, their implementation should be efficient and unintrusive.
 
-Example: Forbidding method calls on weekends
---------------------------------------------
+## Example: Forbidding method calls on weekends
 
 To illustrate how method interceptors work with Ray.Aop, we'll forbid calls to our pizza billing system on weekends. The delivery guys only work Monday thru Friday so we'll prevent pizza from being ordered when it can't be delivered! This example is structurally similar to use of AOP for authorization.
 
@@ -96,8 +95,7 @@ Putting it all together, (and waiting until Saturday), we see the method is inte
 chargeOrder not allowed on weekends!
 ```
 
-Explicit method name match
----------------------------
+## Explicit method name match
 
 ```php
 <?php
@@ -157,8 +155,7 @@ $bind = (new Bind)->bind(RealBillingService::class, [$pointcut]);
 $billing = (new Compiler($tmpDir))->newInstance(RealBillingService::class, [], $bind);
 ```
 
-Priority
---------
+## Priority
 
 The order of interceptor invocation are determined by following rules.
 
@@ -174,8 +171,7 @@ The order of interceptor invocation are determined by following rules.
  */
 ```
 
-Limitations
------------
+## Limitations
 
 Behind the scenes, method interception is implemented by generating code at runtime. Ray.Aop dynamically creates a subclass that applies interceptors by overriding methods.
 
@@ -183,21 +179,47 @@ This approach imposes limits on what classes and methods can be intercepted:
 
  * Classes must be *non-final*
  * Methods must be *public*
- * Methods must be *non-final*
 
-AOP Alliance
-------------
+# Interceptor
+
+In an interceptor a `MethodInvocation` object gets passed to the `invoke` method. We can the decorate the targetted instances so that you run computations before or after any methods on the target are invoked.
+
+```php
+class MyInterceptor implements MethodInterceptor
+{
+    public function invoke(MethodInvocation $invocation)
+    {
+        // Before invocation
+        // ...
+        
+        // Method invocation
+        $result = invocation->proceed();
+        
+        // メソッド実行後
+        // ...
+                
+        return $result;
+    }
+}
+```
+
+With the `MethodInvocation` object, you can access the target method's invocation object, method's and parameters.
+
+ * [`$invocation->proceed()`](https://github.com/ray-di/Ray.Aop/blob/2.x/src/Joinpoint.php#L39) - Invoke method
+ * [`$invocation->getMethod()`](https://github.com/ray-di/Ray.Aop/blob/2.x/src/MethodInvocation.php#L29) -  Get method reflection
+ * [`$invocation->getThis()`](https://github.com/ray-di/Ray.Aop/blob/2.x/src/Joinpoint.php#L48) - Get object
+ * [`$invocation->getArguments()`](https://github.com/ray-di/Ray.Aop/blob/2.x/src/MethodInvocation.php#L29) - Get parameters
+  
+## AOP Alliance
 
 The method interceptor API implemented by Ray.Aop is a part of a public specification called [AOP Alliance](http://aopalliance.sourceforge.net/doc/org/aopalliance/intercept/MethodInterceptor.html).
 
-Requirements
-------------
+## Requirements
 
 * PHP 5.4+
 * hhvm
 
-Installation
-------------
+## Installation
 
 The recommended way to install Ray.Aop is through [Composer](https://github.com/composer/composer).
 
@@ -206,8 +228,7 @@ The recommended way to install Ray.Aop is through [Composer](https://github.com/
 $ composer require ray/aop ~2.0
 ```
 
-Testing Ray.Aop
----------------
+## Testing Ray.Aop
 
 Here's how to install Ray.Aop from source and run the unit tests and demos.
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,20 @@ With the `MethodInvocation` object, you can access the target method's invocatio
  * [`$invocation->getMethod()`](https://github.com/ray-di/Ray.Aop/blob/2.x/src/MethodInvocation.php#L29) -  Get method reflection
  * [`$invocation->getThis()`](https://github.com/ray-di/Ray.Aop/blob/2.x/src/Joinpoint.php#L48) - Get object
  * [`$invocation->getArguments()`](https://github.com/ray-di/Ray.Aop/blob/2.x/src/MethodInvocation.php#L29) - Get parameters
+ 
+An extended `ClassRefletion` and `MethodReflection` holds methos to get annotation(s).
+
+```php
+/** @var $method \Ray\Aop\ReflectionMethod */
+$method = $invocation->getMethod();
+/** @var $class \Ray\Aop\ReflectionClass */
+$class = $invocation->getMethod()->getDeclaringClass();
+```
+ 
+ * [`$method->getAnnotations()`]()     - Get method annotations
+ * [`$method->getAnnotation($name)`]() - Get method annotation
+ * [`$class->->getAnnotations()`]()    - Get class annotations
+ * [`$class->->getAnnotation($name)`]()     - Get class annotation
   
 ## AOP Alliance
 

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -22,7 +22,7 @@
     <rule ref="rulesets/design.xml/DepthOfInheritance" />
     <rule ref="rulesets/design.xml/CouplingBetweenObjects" >
         <properties>
-            <property name="minimum" value="16"/>
+            <property name="minimum" value="20"/>
         </properties>
     </rule>
     <!--naming-->

--- a/src/Bind.php
+++ b/src/Bind.php
@@ -43,7 +43,7 @@ final class Bind implements BindInterface
 
     /**
      * @param ReflectionClass $class
-     * @param array           $pointcuts
+     * @param Pointcut[]      $pointcuts
      */
     private function annotatedMethodsMatch(\ReflectionClass $class, array &$pointcuts)
     {
@@ -148,7 +148,7 @@ final class Bind implements BindInterface
     /**
      * @param ReflectionClass  $class
      * @param ReflectionMethod $method
-     * @param array            $pointcuts
+     * @param Pointcut[]       $pointcuts
      * @param array            $annotations
      *
      * @return array

--- a/src/Bind.php
+++ b/src/Bind.php
@@ -7,8 +7,6 @@
 namespace Ray\Aop;
 
 use Doctrine\Common\Annotations\AnnotationReader;
-use ReflectionClass;
-use ReflectionMethod;
 
 final class Bind implements BindInterface
 {

--- a/src/CodeGen.php
+++ b/src/CodeGen.php
@@ -40,7 +40,7 @@ final class CodeGen implements CodeGenInterface
     private $codeGenMethod;
 
     /**
-     * @var Reader
+     * @var IndexedReader
      */
     private $reader;
 

--- a/src/CodeGen.php
+++ b/src/CodeGen.php
@@ -40,7 +40,7 @@ final class CodeGen implements CodeGenInterface
     private $codeGenMethod;
 
     /**
-     * @var AnnotationReader
+     * @var Reader
      */
     private $reader;
 
@@ -209,7 +209,7 @@ final class CodeGen implements CodeGenInterface
         $methods = $class->getMethods();
         foreach ($methods as $method) {
             $annotations = $this->reader->getMethodAnnotations($method);
-            if (! $annotations) {
+            if ($annotations === []) {
                 continue;
             }
             $methodsAnnotation[$method->getName()] = $annotations;

--- a/src/CodeGen.php
+++ b/src/CodeGen.php
@@ -153,7 +153,7 @@ final class CodeGen implements CodeGenInterface
     }
 
     /**
-     * @param Builder          $builder
+     * @param Builder $builder
      *
      * @return Builder
      */

--- a/src/CodeGen.php
+++ b/src/CodeGen.php
@@ -116,7 +116,7 @@ final class CodeGen implements CodeGenInterface
             ->class($newClassName)
             ->extend($parentClass)
             ->implement('Ray\Aop\WeavedInterface');
-        $builder = $this->addInterceptorProp($builder, $class);
+        $builder = $this->addInterceptorProp($builder);
         $builder = $this->addSerialisedAnnotationProp($builder, $class);
 
         return $builder;
@@ -154,11 +154,10 @@ final class CodeGen implements CodeGenInterface
 
     /**
      * @param Builder          $builder
-     * @param \ReflectionClass $class
      *
      * @return Builder
      */
-    private function addInterceptorProp(Builder $builder, \ReflectionClass $class)
+    private function addInterceptorProp(Builder $builder)
     {
         $builder->addStmt(
             $this->factory

--- a/src/CodeGen.php
+++ b/src/CodeGen.php
@@ -111,6 +111,10 @@ final class CodeGen implements CodeGenInterface
                 $this->factory->property('isIntercepting')->makePrivate()->setDefault(true)
             )->addStmt(
                 $this->factory->property('bind')->makePublic()
+            )->addStmt(
+                $this->factory->property('methodAnnotations')->setDefault([])->makePrivate()
+            )->addStmt(
+                $this->factory->property('classAnnotations')->setDefault([])->makePrivate()
             );
 
         return $builder;

--- a/src/CodeGen.php
+++ b/src/CodeGen.php
@@ -143,7 +143,7 @@ final class CodeGen implements CodeGenInterface
     /**
      * @param \ReflectionClass $class
      *
-     * @return array
+     * @return string
      */
     private function getClassAnnotation(\ReflectionClass $class)
     {

--- a/src/CodeGen.php
+++ b/src/CodeGen.php
@@ -117,13 +117,22 @@ final class CodeGen implements CodeGenInterface
             ->extend($parentClass)
             ->implement('Ray\Aop\WeavedInterface')
             ->addStmt(
-                $this->factory->property('isIntercepting')->makePrivate()->setDefault(true)
+                $this->factory->property('isIntercepting')
+                    ->makePrivate()
+                    ->setDefault(true)
             )->addStmt(
-                $this->factory->property('bind')->makePublic()
+                $this->factory->property('bind')
+                    ->makePublic()
             )->addStmt(
-                $this->factory->property('methodAnnotations')->setDefault($this->getMethodAnnotations($class))->makePublic()
+                $this->factory
+                    ->property('methodAnnotations')
+                    ->setDefault($this->getMethodAnnotations($class))
+                    ->makePublic()
             )->addStmt(
-                $this->factory->property('classAnnotations')->setDefault($this->getClassAnnotation($class))->makePrivate()
+                $this->factory
+                    ->property('classAnnotations')
+                    ->setDefault($this->getClassAnnotation($class))
+                    ->makePublic()
             );
 
         return $builder;
@@ -165,6 +174,9 @@ final class CodeGen implements CodeGenInterface
         $methods = $class->getMethods();
         foreach ($methods as $method) {
             $annotations = $this->reader->getMethodAnnotations($method);
+            if (! $annotations) {
+                continue;
+            }
             $methodsAnnotation[$method->getName()] = $annotations;
         }
 

--- a/src/CodeGen.php
+++ b/src/CodeGen.php
@@ -110,7 +110,6 @@ final class CodeGen implements CodeGenInterface
      */
     private function getClass($newClassName, \ReflectionClass $class)
     {
-
         $parentClass = $class->name;
         $builder = $this->factory
             ->class($newClassName)

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -11,7 +11,6 @@ use PhpParser\Lexer;
 use PhpParser\Parser;
 use PhpParser\PrettyPrinter\Standard as StandardPrettyPrinter;
 use Ray\Aop\Exception\NotWritableException;
-use ReflectionClass;
 
 final class Compiler implements CompilerInterface
 {

--- a/src/Exception/NotWritableException.php
+++ b/src/Exception/NotWritableException.php
@@ -6,8 +6,6 @@
  */
 namespace Ray\Aop\Exception;
 
-use Ray\Di\Exception\ExceptionInterface;
-
-class NotWritableException extends \LogicException
+class NotWritableException extends \LogicException implements ExceptionInterface
 {
 }

--- a/src/Matcher/AnyMatcher.php
+++ b/src/Matcher/AnyMatcher.php
@@ -17,7 +17,7 @@ final class AnyMatcher extends AbstractMatcher
 
     public function __construct()
     {
-        if (! self::$builtinMethods) {
+        if (self::$builtinMethods === []) {
             $this->setBuildInMethods();
         }
     }

--- a/src/MethodInvocation.php
+++ b/src/MethodInvocation.php
@@ -24,7 +24,7 @@ interface MethodInvocation extends Invocation
      * <p>This method is a friendly implementation of the {@link
      * Joinpoint#getStaticPart()} method (same result).
      *
-     * @return \ReflectionMethod method being called.
+     * @return ReflectionMethod method being called.
      */
     public function getMethod();
 }

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * This file is part of the Ray.Aop package
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ */
+namespace Ray\Aop;
+
+interface Reader
+{
+    /**
+     * Gets the annotations applied to a method.
+     *
+     * @return array An array of Annotations.
+     */
+    public function getAnnotations();
+
+    /**
+     * Gets a method annotation.
+     *
+     * @param string $annotationName The name of the annotation.
+     *
+     * @return object|null The Annotation or NULL, if the requested annotation does not exist.
+     */
+    public function getAnnotation($annotationName);
+}

--- a/src/ReflectionClass.php
+++ b/src/ReflectionClass.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * This file is part of the Ray.Aop package
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ */
+namespace Ray\Aop;
+
+class ReflectionClass extends \ReflectionClass implements Reader
+{
+    /**
+     * @var WeavedInterface
+     */
+    private $object;
+
+    /**
+     * Dependencies
+     *
+     * @param WeavedInterface $object
+     */
+    public function setObject(WeavedInterface $object)
+    {
+        $this->object = $object;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAnnotations()
+    {
+        return unserialize($this->object->classAnnotations);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAnnotation($annotationName)
+    {
+        $annotations = $this->getAnnotations();
+        if (isset($annotations[$annotationName])) {
+            return $annotations[$annotationName];
+        }
+
+        return null;
+    }
+}

--- a/src/ReflectionClass.php
+++ b/src/ReflectionClass.php
@@ -14,7 +14,7 @@ class ReflectionClass extends \ReflectionClass implements Reader
     private $object;
 
     /**
-     * Dependencies
+     * Set dependencies
      *
      * @param WeavedInterface $object
      */

--- a/src/ReflectionMethod.php
+++ b/src/ReflectionMethod.php
@@ -31,6 +31,18 @@ final class ReflectionMethod extends \ReflectionMethod
     }
 
     /**
+     * @return ReflectionClass
+     */
+    public function getDeclaringClass()
+    {
+        $originalClass = (new \ReflectionClass($this->object))->getParentClass()->getName();
+        $class =  new ReflectionClass($originalClass);
+        $class->setObject($this->object);
+
+        return $class;
+    }
+
+    /**
      * Gets the annotations applied to a method.
      *
      * @return array An array of Annotations.

--- a/src/ReflectionMethod.php
+++ b/src/ReflectionMethod.php
@@ -6,7 +6,7 @@
  */
 namespace Ray\Aop;
 
-final class ReflectionMethod extends \ReflectionMethod
+final class ReflectionMethod extends \ReflectionMethod implements Reader
 {
     /**
      * @var WeavedInterface
@@ -19,7 +19,7 @@ final class ReflectionMethod extends \ReflectionMethod
     private $method;
 
     /**
-     * Dependencies
+     * Set dependencies
      *
      * @param WeavedInterface   $object
      * @param \ReflectionMethod $method
@@ -43,9 +43,7 @@ final class ReflectionMethod extends \ReflectionMethod
     }
 
     /**
-     * Gets the annotations applied to a method.
-     *
-     * @return array An array of Annotations.
+     * {@inheritdoc}
      */
     public function getAnnotations()
     {
@@ -58,11 +56,7 @@ final class ReflectionMethod extends \ReflectionMethod
     }
 
     /**
-     * Gets a method annotation.
-     *
-     * @param string $annotationName The name of the annotation.
-     *
-     * @return object|null The Annotation or NULL, if the requested annotation does not exist.
+     * {@inheritdoc}
      */
     public function getAnnotation($annotationName)
     {

--- a/src/ReflectionMethod.php
+++ b/src/ReflectionMethod.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * This file is part of the Ray.Aop package
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ */
+namespace Ray\Aop;
+
+final class ReflectionMethod extends \ReflectionMethod
+{
+    /**
+     * @var WeavedInterface
+     */
+    private $object;
+
+    /**
+     * @var string
+     */
+    private $method;
+
+    /**
+     * Dependencies
+     *
+     * @param WeavedInterface   $object
+     * @param \ReflectionMethod $method
+     */
+    public function setObject(WeavedInterface $object, \ReflectionMethod $method)
+    {
+        $this->object = $object;
+        $this->method = $method->getName();
+    }
+
+    /**
+     * Gets the annotations applied to a method.
+     *
+     * @return array An array of Annotations.
+     */
+    public function getAnnotations()
+    {
+        $annotations = unserialize($this->object->methodAnnotations);
+        if (isset($annotations[$this->method])) {
+            return $annotations[$this->method];
+        }
+
+        return [];
+    }
+
+    /**
+     * Gets a method annotation.
+     *
+     * @param string $annotationName The name of the annotation.
+     *
+     * @return object|null The Annotation or NULL, if the requested annotation does not exist.
+     */
+    public function getAnnotation($annotationName)
+    {
+        $annotations = $this->getAnnotations();
+        if (isset($annotations[$annotationName])) {
+            return $annotations[$annotationName];
+        }
+
+        return null;
+    }
+}

--- a/src/ReflectiveMethodInvocation.php
+++ b/src/ReflectiveMethodInvocation.php
@@ -52,7 +52,11 @@ final class ReflectiveMethodInvocation implements MethodInvocation
     public function getMethod()
     {
         if ($this->object instanceof WeavedInterface) {
-            return (new \ReflectionObject($this->object))->getParentClass()->getMethod($this->method->getName());
+            $class = (new \ReflectionObject($this->object))->getParentClass();
+            $method = new ReflectionMethod($class->getName(), $this->method->getName());
+            $method->setObject($this->object, $this->method);
+
+            return $method;
         }
 
         return $this->method;

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -4,7 +4,6 @@ namespace Ray\Aop;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use Ray\Aop\Exception\NotWritableException;
-use TokenReflection\ReflectionClass;
 
 class CompilerTest extends \PHPUnit_Framework_TestCase
 {
@@ -222,5 +221,18 @@ class CompilerTest extends \PHPUnit_Framework_TestCase
         $this->bind->bind(FakeMock::class, [$pointcut]);
         $class = $this->compiler->compile(FakeMock::class, $this->bind);
         $this->assertTrue(class_exists($class));
+    }
+
+    public function testMethodAnnotationReader()
+    {
+        $bind = (new Bind)->bindInterceptors('getDouble', [new FakeMethodAnnotationReaderInterceptor]);
+        $compiler = new Compiler($_ENV['TMP_DIR']);
+        $mock = $compiler->newInstance(FakeAnnotateClass::class, [], $bind);
+        /* @var $mock FakeAnnotateClass */
+        list($methodAnnotations, $methodAnnotation) = $mock->getDouble(1);
+        $this->assertInstanceOf(FakeMarker::class, $methodAnnotation);
+        $this->assertCount(3, $methodAnnotations);
+        $annotation = array_shift($methodAnnotations);
+        $this->assertInstanceOf(FakeMarker3::class, $annotation);
     }
 }

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -235,4 +235,26 @@ class CompilerTest extends \PHPUnit_Framework_TestCase
         $annotation = array_shift(FakeMethodAnnotationReaderInterceptor::$methodAnnotations);
         $this->assertInstanceOf(FakeMarker3::class, $annotation);
     }
+
+    /**
+     * @depends testMethodAnnotationReader
+     */
+    public function testClassAnnotationReader()
+    {
+        $this->assertInstanceOf(FakeClassAnnotation::class, FakeMethodAnnotationReaderInterceptor::$classAnnotation);
+        $this->assertCount(2, FakeMethodAnnotationReaderInterceptor::$classAnnotations);
+        $annotation = array_shift(FakeMethodAnnotationReaderInterceptor::$classAnnotations);
+        $this->assertInstanceOf(FakeResource::class, $annotation);
+    }
+
+    public function testMethodAnnotationReaderReturnNull()
+    {
+        $bind = (new Bind)->bindInterceptors('returnSame', [new FakeMethodAnnotationReaderInterceptor]);
+        $compiler = new Compiler($_ENV['TMP_DIR']);
+        $mock = $compiler->newInstance(FakeMock::class, [], $bind);
+        /* @var $mock FakeMock */
+        $mock->returnSame(1);
+        $this->assertNull(FakeMethodAnnotationReaderInterceptor::$methodAnnotation);
+        $this->assertCount(0, FakeMethodAnnotationReaderInterceptor::$methodAnnotations);
+    }
 }

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -202,7 +202,7 @@ class CompilerTest extends \PHPUnit_Framework_TestCase
         $file = file((new \ReflectionClass($class))->getFileName());
         $expected = '    function returnSame(array $arrayParam, callable $callableParam)
 ';
-        $this->assertSame($expected, $file[5]);
+        $this->assertSame($expected, $file[7]);
     }
 
     public function testNotWritable()

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -32,9 +32,7 @@ class CompilerTest extends \PHPUnit_Framework_TestCase
     public function tearDown()
     {
         parent::tearDown();
-        foreach (new \RecursiveDirectoryIterator($_ENV['TMP_DIR'], \FilesystemIterator::SKIP_DOTS) as $file) {
-            unlink($file);
-        }
+        array_map('unlink', glob("{$_ENV['TMP_DIR']}/*.php"));
     }
 
     public function testBuildClass()

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -229,10 +229,10 @@ class CompilerTest extends \PHPUnit_Framework_TestCase
         $compiler = new Compiler($_ENV['TMP_DIR']);
         $mock = $compiler->newInstance(FakeAnnotateClass::class, [], $bind);
         /* @var $mock FakeAnnotateClass */
-        list($methodAnnotations, $methodAnnotation) = $mock->getDouble(1);
-        $this->assertInstanceOf(FakeMarker::class, $methodAnnotation);
-        $this->assertCount(3, $methodAnnotations);
-        $annotation = array_shift($methodAnnotations);
+        $mock->getDouble(1);
+        $this->assertInstanceOf(FakeMarker::class, FakeMethodAnnotationReaderInterceptor::$methodAnnotation);
+        $this->assertCount(3, FakeMethodAnnotationReaderInterceptor::$methodAnnotations);
+        $annotation = array_shift(FakeMethodAnnotationReaderInterceptor::$methodAnnotations);
         $this->assertInstanceOf(FakeMarker3::class, $annotation);
     }
 }

--- a/tests/Fake/FakeAnnotateClass.php
+++ b/tests/Fake/FakeAnnotateClass.php
@@ -4,6 +4,7 @@ namespace Ray\Aop;
 
 /**
  * @Ray\Aop\FakeResource
+ * @FakeClassAnnotation("item")
  */
 class FakeAnnotateClass
 {

--- a/tests/Fake/FakeAssisted.php
+++ b/tests/Fake/FakeAssisted.php
@@ -5,6 +5,7 @@
  * @license http://opensource.org/licenses/MIT MIT
  */
 namespace Ray\Aop;
+
 use Ray\Aop\Annotation\AbstractAssisted;
 
 /**

--- a/tests/Fake/FakeAssistedConsumer.php
+++ b/tests/Fake/FakeAssistedConsumer.php
@@ -4,10 +4,17 @@ namespace Ray\Aop;
 
 use Ray\Aop\FakeAssisted;
 
+/**
+ * @FakeResource
+ * @FakeClassAnnotation
+ */
 class FakeAssistedConsumer
 {
     /**
      * @FakeAssisted({"b", "c"})
+     * @FakeMarker
+     * @FakeMarker2
+     * @FakeMarker3
      */
     public function run($a, $b, $c)
     {

--- a/tests/Fake/FakeAssistedConsumer.php
+++ b/tests/Fake/FakeAssistedConsumer.php
@@ -2,8 +2,6 @@
 
 namespace Ray\Aop;
 
-use Ray\Aop\FakeAssisted;
-
 /**
  * @FakeResource
  * @FakeClassAnnotation

--- a/tests/Fake/FakeClassAnnotation.php
+++ b/tests/Fake/FakeClassAnnotation.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Ray\Aop;
+
+/**
+ * @Annotation
+ * @Target("CLASS")
+ */
+final class FakeClassAnnotation
+{
+    public $value;
+}

--- a/tests/Fake/FakeMethodAnnotationReaderInterceptor.php
+++ b/tests/Fake/FakeMethodAnnotationReaderInterceptor.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Ray\Aop;
+
+class FakeMethodAnnotationReaderInterceptor implements MethodInterceptor
+{
+    public function invoke(MethodInvocation $invocation)
+    {
+        $methodAnnotations = $invocation->getMethod()->getAnnotations();
+        $methodAnnotation = $invocation->getMethod()->getAnnotation(FakeMarker::class);
+
+        return [$methodAnnotations, $methodAnnotation];
+    }
+}

--- a/tests/Fake/FakeMethodAnnotationReaderInterceptor.php
+++ b/tests/Fake/FakeMethodAnnotationReaderInterceptor.php
@@ -4,6 +4,8 @@ namespace Ray\Aop;
 
 class FakeMethodAnnotationReaderInterceptor implements MethodInterceptor
 {
+    public static $classAnnotations;
+    public static $classAnnotation;
     public static $methodAnnotations;
     public static $methodAnnotation;
 
@@ -11,6 +13,9 @@ class FakeMethodAnnotationReaderInterceptor implements MethodInterceptor
     {
         self::$methodAnnotations = $invocation->getMethod()->getAnnotations();
         self::$methodAnnotation = $invocation->getMethod()->getAnnotation(FakeMarker::class);
+        self::$classAnnotations = $invocation->getMethod()->getDeclaringClass()->getAnnotations();
+        self::$classAnnotation = $invocation->getMethod()->getDeclaringClass()->getAnnotation(FakeClassAnnotation::class);
+
         return $invocation->proceed();
     }
 }

--- a/tests/Fake/FakeMethodAnnotationReaderInterceptor.php
+++ b/tests/Fake/FakeMethodAnnotationReaderInterceptor.php
@@ -4,11 +4,13 @@ namespace Ray\Aop;
 
 class FakeMethodAnnotationReaderInterceptor implements MethodInterceptor
 {
+    public static $methodAnnotations;
+    public static $methodAnnotation;
+
     public function invoke(MethodInvocation $invocation)
     {
-        $methodAnnotations = $invocation->getMethod()->getAnnotations();
-        $methodAnnotation = $invocation->getMethod()->getAnnotation(FakeMarker::class);
-
-        return [$methodAnnotations, $methodAnnotation];
+        self::$methodAnnotations = $invocation->getMethod()->getAnnotations();
+        self::$methodAnnotation = $invocation->getMethod()->getAnnotation(FakeMarker::class);
+        return $invocation->proceed();
     }
 }

--- a/tests/Matcher/LogicalAndMatcherTest.php
+++ b/tests/Matcher/LogicalAndMatcherTest.php
@@ -3,7 +3,6 @@
 namespace Ray\Aop\Matcher;
 
 use Ray\Aop\FakeAnnotateClass;
-use Ray\Aop\FakeClass;
 use Ray\Aop\FakeMatcher;
 
 class LogicalAndMatcherTest extends \PHPUnit_Framework_TestCase

--- a/tests/ReflectiveMethodInvocationTest.php
+++ b/tests/ReflectiveMethodInvocationTest.php
@@ -18,7 +18,7 @@ class ReflectiveMethodInvocationTest extends \PHPUnit_Framework_TestCase
     {
         parent::setUp();
         $this->fake = new FakeClass;
-        $this->invocation = new ReflectiveMethodInvocation($this->fake, new ReflectionMethod($this->fake, 'add'), new Arguments([1]));
+        $this->invocation = new ReflectiveMethodInvocation($this->fake, new \ReflectionMethod($this->fake, 'add'), new Arguments([1]));
     }
 
     public function testGetMethod()
@@ -62,7 +62,7 @@ class ReflectiveMethodInvocationTest extends \PHPUnit_Framework_TestCase
     public function testGetParentMethod()
     {
         $fake = new FakeWeavedClass;
-        $invocation = new ReflectiveMethodInvocation($fake, new ReflectionMethod($fake, 'add'), new Arguments([1]));
+        $invocation = new ReflectiveMethodInvocation($fake, new \ReflectionMethod($fake, 'add'), new Arguments([1]));
         $method = $invocation->getMethod();
         $this->assertSame(FakeClass::class, $method->class);
         $this->assertSame('add', $method->name);
@@ -71,7 +71,7 @@ class ReflectiveMethodInvocationTest extends \PHPUnit_Framework_TestCase
     public function testProceedMultipleInterceptors()
     {
         $fake = new FakeWeavedClass;
-        $invocation = new ReflectiveMethodInvocation($fake, new ReflectionMethod($fake, 'add'), new Arguments([1]), [new FakeInterceptor, new FakeInterceptor]);
+        $invocation = new ReflectiveMethodInvocation($fake, new \ReflectionMethod($fake, 'add'), new Arguments([1]), [new FakeInterceptor, new FakeInterceptor]);
         $invocation->proceed();
         $this->assertSame(1, $fake->a);
     }

--- a/tests/ReflectiveMethodInvocationTest.php
+++ b/tests/ReflectiveMethodInvocationTest.php
@@ -18,7 +18,7 @@ class ReflectiveMethodInvocationTest extends \PHPUnit_Framework_TestCase
     {
         parent::setUp();
         $this->fake = new FakeClass;
-        $this->invocation = new ReflectiveMethodInvocation($this->fake, new \ReflectionMethod($this->fake, 'add'), new Arguments([1]));
+        $this->invocation = new ReflectiveMethodInvocation($this->fake, new ReflectionMethod($this->fake, 'add'), new Arguments([1]));
     }
 
     public function testGetMethod()
@@ -62,7 +62,7 @@ class ReflectiveMethodInvocationTest extends \PHPUnit_Framework_TestCase
     public function testGetParentMethod()
     {
         $fake = new FakeWeavedClass;
-        $invocation = new ReflectiveMethodInvocation($fake, new \ReflectionMethod($fake, 'add'), new Arguments([1]));
+        $invocation = new ReflectiveMethodInvocation($fake, new ReflectionMethod($fake, 'add'), new Arguments([1]));
         $method = $invocation->getMethod();
         $this->assertSame(FakeClass::class, $method->class);
         $this->assertSame('add', $method->name);
@@ -71,7 +71,7 @@ class ReflectiveMethodInvocationTest extends \PHPUnit_Framework_TestCase
     public function testProceedMultipleInterceptors()
     {
         $fake = new FakeWeavedClass;
-        $invocation = new ReflectiveMethodInvocation($fake, new \ReflectionMethod($fake, 'add'), new Arguments([1]), [new FakeInterceptor, new FakeInterceptor]);
+        $invocation = new ReflectiveMethodInvocation($fake, new ReflectionMethod($fake, 'add'), new Arguments([1]), [new FakeInterceptor, new FakeInterceptor]);
         $invocation->proceed();
         $this->assertSame(1, $fake->a);
     }


### PR DESCRIPTION
Reading annotation on runtime is costly. Caching works, but we need to maintain for it.

This new annotation compiler works only in code generation. Annotation object was made and put into its own generated code.

To use this fast annotation reading, use package `ReflectionClass` or `ReflectionMethod` which extended PHP native reflection. It implements new `Reader` interface.

``` php
<?php
class FakeMethodAnnotationReaderInterceptor implements MethodInterceptor
{
    public function invoke(MethodInvocation $invocation)
    {
        $methodAnnotations = $invocation->getMethod()->getAnnotations();
        $methodAnnotation = $invocation->getMethod()->getAnnotation(FakeMarker::class);
        $classAnnotations = $invocation->getMethod()->getDeclaringClass()->getAnnotations();
        $classAnnotation = $invocation->getMethod()->getDeclaringClass()->getAnnotation(FakeClassAnnotation::class);

        return $invocation->proceed();
    }
}
```

You can read annotations on runtime in interceptor more easily.
