### PR TITLE
Support php-parser 1 and 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,20 @@ php:
   - 5.6
   - hhvm
   - 7
+matrix:
+  include:
+    - php: 5.5
+      env: dependencies=lowest
+    - php: 5.6
+      env: dependencies=lowest
+    - php: hhvm
+      env: dependencies=lowest
+    - php: 7
+      env: dependencies=lowest
 before_script:
   - composer self-update
-  - composer install
+  - if [ -z "$dependencies" ]; then composer install; fi;
+  - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest; fi;
 script:
   - phpunit --coverage-clover=coverage.clover
 after_script:

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "doctrine/annotations": "~1.1",
-        "nikic/php-parser": "~1.0|~2.0"
+        "doctrine/annotations": "^1.2.7",
+        "nikic/php-parser": "~1.3||~2.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.4.0",
         "doctrine/annotations": "~1.1",
-        "nikic/php-parser": "~1.0"
+        "nikic/php-parser": "~1.0|~2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -7,8 +7,6 @@
 namespace Ray\Aop;
 
 use PhpParser\BuilderFactory;
-use PhpParser\Lexer;
-use PhpParser\Parser;
 use PhpParser\PrettyPrinter\Standard as StandardPrettyPrinter;
 use Ray\Aop\Exception\NotWritableException;
 
@@ -35,7 +33,7 @@ final class Compiler implements CompilerInterface
         }
         $this->classDir = $classDir;
         $this->codeGen = $codeGen ?: new CodeGen(
-            new Parser(new Lexer()),
+            ParserFactory::create(),
             new BuilderFactory(),
             new StandardPrettyPrinter()
         );

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -33,7 +33,7 @@ final class Compiler implements CompilerInterface
         }
         $this->classDir = $classDir;
         $this->codeGen = $codeGen ?: new CodeGen(
-            ParserFactory::create(),
+            (new ParserFactory)->newInstance(),
             new BuilderFactory(),
             new StandardPrettyPrinter()
         );

--- a/src/ParserFactory.php
+++ b/src/ParserFactory.php
@@ -12,7 +12,7 @@ use PhpParser\ParserFactory as PHPParserFactory;
 
 class ParserFactory
 {
-    public static function create()
+    public function newInstance()
     {
         if (class_exists('PhpParser\ParserFactory')) {
             return (new PHPParserFactory)->create(PHPParserFactory::PREFER_PHP7);

--- a/src/ParserFactory.php
+++ b/src/ParserFactory.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * This file is part of the Ray.Aop package
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ */
+namespace Ray\Aop;
+
+use PhpParser\Lexer;
+use PhpParser\Parser;
+use PhpParser\ParserFactory as PHPParserFactory;
+
+class ParserFactory
+{
+    public static function create()
+    {
+        if (class_exists('PhpParser\ParserFactory')) {
+            return (new PHPParserFactory)->create(PHPParserFactory::PREFER_PHP7);
+        }
+
+        return new Parser(new Lexer());
+    }
+}

--- a/tests/CodeGenTest.php
+++ b/tests/CodeGenTest.php
@@ -11,7 +11,7 @@ class CodeGenTest extends \PHPUnit_Framework_TestCase
 {
     public function testAddNullDefaultWithAssisted()
     {
-        $codeGen = new CodeGen(ParserFactory::create(), new BuilderFactory, new Standard);
+        $codeGen = new CodeGen((new ParserFactory)->newInstance(), new BuilderFactory, new Standard);
         $bind = new Bind;
         $bind->bindInterceptors('run', []);
         $code = $codeGen->generate('a', new \ReflectionClass(FakeAssistedConsumer::class), $bind);

--- a/tests/CodeGenTest.php
+++ b/tests/CodeGenTest.php
@@ -5,15 +5,13 @@ namespace Ray\Aop;
 namespace Ray\Aop;
 
 use PhpParser\BuilderFactory;
-use PhpParser\Lexer;
-use PhpParser\Parser;
 use PhpParser\PrettyPrinter\Standard;
 
 class CodeGenTest extends \PHPUnit_Framework_TestCase
 {
     public function testAddNullDefaultWithAssisted()
     {
-        $codeGen = new CodeGen(new Parser(new Lexer), new BuilderFactory, new Standard);
+        $codeGen = new CodeGen(ParserFactory::create(), new BuilderFactory, new Standard);
         $bind = new Bind;
         $bind->bindInterceptors('run', []);
         $code = $codeGen->generate('a', new \ReflectionClass(FakeAssistedConsumer::class), $bind);

--- a/tests/ParserFactoryTest.php
+++ b/tests/ParserFactoryTest.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Ray\Aop;
+
+class ParserFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCreate()
+    {
+        $this->assertInstanceOf('PhpParser\Parser', ParserFactory::create());
+    }
+}

--- a/tests/ParserFactoryTest.php
+++ b/tests/ParserFactoryTest.php
@@ -6,6 +6,6 @@ class ParserFactoryTest extends \PHPUnit_Framework_TestCase
 {
     public function testCreate()
     {
-        $this->assertInstanceOf('PhpParser\Parser', ParserFactory::create());
+        $this->assertInstanceOf('PhpParser\Parser', (new ParserFactory)->newInstance());
     }
 }


### PR DESCRIPTION
Ran into an issue with a new project where this package needs php-parser 1 and another package needs 2. Decided to look into how hard it is to make this package support both. Turns out not that hard.

There are a couple of things in this PR:
- [X] A parser factory creating a parser depending of the php-parser version
- [X] A test for the parser factory
- [X] Normal `composer install` test run on travis and `update --prefer-lowest` test run on travis to ensure both php-parser 1 and 2 are tested
- [X] Sharper version targeting for targeted packages, errors came up during `--prefer-lowest` testing
