### PR TITLE
Allow more matchers on logicOr/logicAnd

### DIFF
--- a/src/Matcher.php
+++ b/src/Matcher.php
@@ -55,25 +55,21 @@ class Matcher implements MatcherInterface
         return new BuiltinMatcher(__FUNCTION__, [$prefix]);
     }
 
-    // @codingStandardsIgnoreStart
-
     /**
      * {@inheritdoc}
      */
-    public function logicalOr(AbstractMatcher $matcherA, AbstractMatcher $matcherB)
+    public function logicalOr(AbstractMatcher $matcher, AbstractMatcher ...$otherMatchers)
     {
-        return new BuiltinMatcher(__FUNCTION__, func_get_args());
+        return new BuiltinMatcher(__FUNCTION__, [$matcher] + $otherMatchers);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function logicalAnd(AbstractMatcher $matcherA, AbstractMatcher $matcherB)
+    public function logicalAnd(AbstractMatcher $matcher, AbstractMatcher ...$otherMatchers)
     {
-        return new BuiltinMatcher(__FUNCTION__, func_get_args());
+        return new BuiltinMatcher(__FUNCTION__, [$matcher] + $otherMatchers);
     }
-
-    // @codingStandardsIgnoreEnd
 
     /**
      * {@inheritdoc}

--- a/src/Matcher.php
+++ b/src/Matcher.php
@@ -55,12 +55,14 @@ class Matcher implements MatcherInterface
         return new BuiltinMatcher(__FUNCTION__, [$prefix]);
     }
 
+    // @codingStandardsIgnoreStart
+
     /**
      * {@inheritdoc}
      */
     public function logicalOr(AbstractMatcher $matcherA, AbstractMatcher $matcherB)
     {
-        return new BuiltinMatcher(__FUNCTION__, [$matcherA, $matcherB]);
+        return new BuiltinMatcher(__FUNCTION__, func_get_args());
     }
 
     /**
@@ -68,8 +70,10 @@ class Matcher implements MatcherInterface
      */
     public function logicalAnd(AbstractMatcher $matcherA, AbstractMatcher $matcherB)
     {
-        return new BuiltinMatcher(__FUNCTION__, [$matcherA, $matcherB]);
+        return new BuiltinMatcher(__FUNCTION__, func_get_args());
     }
+
+    // @codingStandardsIgnoreEnd
 
     /**
      * {@inheritdoc}

--- a/src/MatcherInterface.php
+++ b/src/MatcherInterface.php
@@ -42,25 +42,29 @@ interface MatcherInterface
      */
     public function startsWith($prefix);
 
+    // @codingStandardsIgnoreStart
+
     /**
-     * Returns a matcher which matches if combining two matchers using a logical OR.
+     * Returns a matcher which matches if combining two or more matchers using a logical OR.
      *
      * @param AbstractMatcher $matcherA
-     * @param AbstractMatcher $matcherB
+     * @param AbstractMatcher ...$matcherB
      *
      * @return AbstractMatcher
      */
     public function logicalOr(AbstractMatcher $matcherA, AbstractMatcher $matcherB);
 
     /**
-     * Returns a matcher which matches if combining two matchers using a logical AND.
+     * Returns a matcher which matches if combining two or more matchers using a logical AND.
      *
      * @param AbstractMatcher $matcherA
-     * @param AbstractMatcher $matcherB
+     * @param AbstractMatcher ...$matcherB
      *
      * @return AbstractMatcher
      */
     public function logicalAnd(AbstractMatcher $matcherA, AbstractMatcher $matcherB);
+
+    // @codingStandardsIgnoreEnd
 
     /**
      * Returns a matcher which does NOT matches.

--- a/src/MatcherInterface.php
+++ b/src/MatcherInterface.php
@@ -42,29 +42,25 @@ interface MatcherInterface
      */
     public function startsWith($prefix);
 
-    // @codingStandardsIgnoreStart
-
     /**
      * Returns a matcher which matches if combining two or more matchers using a logical OR.
      *
-     * @param AbstractMatcher $matcherA
-     * @param AbstractMatcher ...$matcherB
+     * @param AbstractMatcher   $matcher
+     * @param AbstractMatcher[] ...$otherMatchers
      *
      * @return AbstractMatcher
      */
-    public function logicalOr(AbstractMatcher $matcherA, AbstractMatcher $matcherB);
+    public function logicalOr(AbstractMatcher $matcher, AbstractMatcher ...$otherMatchers);
 
     /**
      * Returns a matcher which matches if combining two or more matchers using a logical AND.
      *
-     * @param AbstractMatcher $matcherA
-     * @param AbstractMatcher ...$matcherB
+     * @param AbstractMatcher   $matcher
+     * @param AbstractMatcher[] ...$otherMatchers
      *
      * @return AbstractMatcher
      */
-    public function logicalAnd(AbstractMatcher $matcherA, AbstractMatcher $matcherB);
-
-    // @codingStandardsIgnoreEnd
+    public function logicalAnd(AbstractMatcher $matcher, AbstractMatcher ...$otherMatchers);
 
     /**
      * Returns a matcher which does NOT matches.

--- a/tests/MatcherTest.php
+++ b/tests/MatcherTest.php
@@ -12,7 +12,9 @@ class MatcherTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(BuiltinMatcher::class, (new Matcher)->any());
         $this->assertInstanceOf(BuiltinMatcher::class, (new Matcher)->annotatedWith(FakeResource::class));
         $this->assertInstanceOf(BuiltinMatcher::class, (new Matcher)->logicalAnd(new FakeMatcher, new FakeMatcher));
+        $this->assertInstanceOf(BuiltinMatcher::class, (new Matcher)->logicalAnd(new FakeMatcher, new FakeMatcher, new FakeMatcher));
         $this->assertInstanceOf(BuiltinMatcher::class, (new Matcher)->logicalOr(new FakeMatcher, new FakeMatcher(false)));
+        $this->assertInstanceOf(BuiltinMatcher::class, (new Matcher)->logicalOr(new FakeMatcher, new FakeMatcher, new FakeMatcher(false)));
 
         $this->assertInstanceOf(BuiltinMatcher::class, (new Matcher)->logicalNot(new FakeMatcher));
         $this->assertInstanceOf(BuiltinMatcher::class, (new Matcher)->startsWith('a'));


### PR DESCRIPTION
`(new Matcher)->logicOr(...)`, `(new Matcher)->logicAnd(...)`
で 3つ以上の matcher を受けれるように修正

`php>=5.4.0` で可変長引数が使えないので、微妙ですが所々 `@codingStandardsIgnore` 入れてます
