### PR TITLE
Allow more matchers on logicalOr/logicalAnd

### DIFF
--- a/src/Matcher.php
+++ b/src/Matcher.php
@@ -55,12 +55,14 @@ class Matcher implements MatcherInterface
         return new BuiltinMatcher(__FUNCTION__, [$prefix]);
     }
 
+    // @codingStandardsIgnoreStart
+
     /**
      * {@inheritdoc}
      */
     public function logicalOr(AbstractMatcher $matcherA, AbstractMatcher $matcherB)
     {
-        return new BuiltinMatcher(__FUNCTION__, [$matcherA, $matcherB]);
+        return new BuiltinMatcher(__FUNCTION__, func_get_args());
     }
 
     /**
@@ -68,8 +70,10 @@ class Matcher implements MatcherInterface
      */
     public function logicalAnd(AbstractMatcher $matcherA, AbstractMatcher $matcherB)
     {
-        return new BuiltinMatcher(__FUNCTION__, [$matcherA, $matcherB]);
+        return new BuiltinMatcher(__FUNCTION__, func_get_args());
     }
+
+    // @codingStandardsIgnoreEnd
 
     /**
      * {@inheritdoc}

--- a/tests/MatcherTest.php
+++ b/tests/MatcherTest.php
@@ -12,7 +12,9 @@ class MatcherTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(BuiltinMatcher::class, (new Matcher)->any());
         $this->assertInstanceOf(BuiltinMatcher::class, (new Matcher)->annotatedWith(FakeResource::class));
         $this->assertInstanceOf(BuiltinMatcher::class, (new Matcher)->logicalAnd(new FakeMatcher, new FakeMatcher));
+        $this->assertInstanceOf(BuiltinMatcher::class, (new Matcher)->logicalAnd(new FakeMatcher, new FakeMatcher, new FakeMatcher));
         $this->assertInstanceOf(BuiltinMatcher::class, (new Matcher)->logicalOr(new FakeMatcher, new FakeMatcher(false)));
+        $this->assertInstanceOf(BuiltinMatcher::class, (new Matcher)->logicalOr(new FakeMatcher, new FakeMatcher, new FakeMatcher(false)));
 
         $this->assertInstanceOf(BuiltinMatcher::class, (new Matcher)->logicalNot(new FakeMatcher));
         $this->assertInstanceOf(BuiltinMatcher::class, (new Matcher)->startsWith('a'));


### PR DESCRIPTION
#66 #68 続き

`MatcherInterface` で可変長引数を利用して複数Matcher(3つ以上)に対応したいが、
セマンティクバージョニングによりメジャーバージョン変更の必要があるため `Matcher` の実装のみ変更
