### PR TITLE
Ignore original time stamp for AOP class name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+dist: trusty
 sudo: false
 php:
   - 5.6

--- a/src/Bind.php
+++ b/src/Bind.php
@@ -65,11 +65,7 @@ final class Bind implements BindInterface
      */
     public function toString($salt)
     {
-        $shortHash = function ($data) {
-            return strtr(rtrim(base64_encode(pack('H*', sprintf('%u', crc32(serialize($data))))), '='), '+/', '-_');
-        };
-
-        return $shortHash(serialize($this->bindings) . $salt);
+        return strtr(rtrim(base64_encode(pack('H*', sprintf('%u', crc32(serialize($this->bindings))))), '='), '+/', '-_');
     }
 
     /**

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -97,8 +97,7 @@ final class Compiler implements CompilerInterface
      */
     private function getNewClassName($class, BindInterface $bind)
     {
-        $fileTime = filemtime((new \ReflectionClass($class))->getFileName());
-        $newClass = sprintf('%s_%s', str_replace('\\', '_', $class), $bind->toString($fileTime));
+        $newClass = sprintf('%s_%s', str_replace('\\', '_', $class), $bind->toString(''));
 
         return $newClass;
     }


### PR DESCRIPTION
to avoid auto save confusion