### PR TITLE
MethodInvocation::getNamedArguments() method

### DIFF
--- a/src/Invocation.php
+++ b/src/Invocation.php
@@ -20,10 +20,14 @@ interface Invocation extends Joinpoint
     /**
      * Get the arguments as an array object.
      *
-     * It is possible to change element values within this
-     * array to change the arguments.
-     *
-     * @return \ArrayObject the argument of the invocation
+     * @return \ArrayObject the argument of the invocation ['arg1', 'arg2']
      */
     public function getArguments() : \ArrayObject;
+
+    /**
+     * Get the named arguments as an array object.
+     *
+     * @return \ArrayObject the argument of the invocation  [`paramName1'=>'arg1', `paramName2'=>'arg2']
+     */
+    public function getNamedArguments() : \ArrayObject;
 }

--- a/src/ReflectiveMethodInvocation.php
+++ b/src/ReflectiveMethodInvocation.php
@@ -75,6 +75,21 @@ final class ReflectiveMethodInvocation implements MethodInvocation
     /**
      * {@inheritdoc}
      */
+    public function getNamedArguments() : \ArrayObject
+    {
+        $args = $this->getArguments();
+        $paramas = $this->getMethod()->getParameters();
+        $namedParams = new \ArrayObject;
+        foreach ($paramas as $param) {
+            $namedParams[$param->getName()] = $args[$param->getPosition()];
+        }
+
+        return $namedParams;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function proceed()
     {
         if ($this->interceptors === []) {

--- a/tests/ReflectiveMethodInvocationTest.php
+++ b/tests/ReflectiveMethodInvocationTest.php
@@ -83,4 +83,10 @@ class ReflectiveMethodInvocationTest extends TestCase
         $invocation->proceed();
         $this->assertSame(1, $fake->a);
     }
+
+    public function testGetNamedArguments()
+    {
+        $args = $this->invocation->getNamedArguments();
+        $this->assertSame((array) $args, ['n' => 1]);
+    }
 }


### PR DESCRIPTION
When this method 
```php
public function foo($a, $b)
{
}    
```
is called as `->foo(1, 2);`,
Arguments can be fetched as followings in the interceptor.

```php
public function invoke(MethodInvocation $invocation)
{
    $arguments = (array) $invocation->getNamedArguments();
    // [1, 2]
    $namedArguments = (array) $invocation->getNamedArguments();
    // ['a' => 1, 'b' => 2]
}