### PR TITLE
Avoid “The use statement with non-compound name" error

### DIFF
--- a/src/CodeGenMethod.php
+++ b/src/CodeGenMethod.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Ray\Aop;
 
+use function class_exists;
 use Doctrine\Common\Annotations\AnnotationReader;
+use function is_string;
 use PhpParser\Builder\Method;
 use PhpParser\Builder\Param;
 use PhpParser\BuilderFactory;
@@ -158,6 +160,9 @@ final class CodeGenMethod
         $paramString = (string) $param;
         $isNullableType = is_int(strpos($paramString, '<required>')) && is_int(strpos($paramString, 'or NULL'));
         $destType = $isNullableType ? new NullableType((string) $type) : (string) $type;
+        if (is_string($destType) && class_exists($destType)) {
+            $destType = '\\' . $destType;
+        }
         $paramStmt->setTypeHint($destType);
     }
 

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -73,21 +73,22 @@ final class Compiler implements CompilerInterface
         if ($this->hasNoBinding($class, $bind)) {
             return $class;
         }
-        $newClass = $this->getNewClassName($class, $bind);
-        if (class_exists($newClass)) {
-            return $newClass;
+        $baseName = $this->getBaseName($class, $bind);
+        $newClassName = 'RayAop\\' . $baseName;
+        if (class_exists($newClassName)) {
+            return $newClassName;
         }
-        $file = "{$this->classDir}/{$newClass}.php";
+        $file = "{$this->classDir}/{$baseName}.php";
         if (file_exists($file)) {
             /** @noinspection UntrustedInclusionInspection */
             /** @noinspection PhpIncludeInspection */
             include $file;
 
-            return $newClass;
+            return $newClassName;
         }
-        $this->includeGeneratedCode($newClass, new ReflectionClass($class), $file, $bind);
+        $this->includeGeneratedCode($baseName, new ReflectionClass($class), $file, $bind);
 
-        return $newClass;
+        return $newClassName;
     }
 
     private function hasNoBinding($class, BindInterface $bind) : bool
@@ -97,7 +98,7 @@ final class Compiler implements CompilerInterface
         return ! $bind->getBindings() && ! $hasMethod;
     }
 
-    private function getNewClassName($class, BindInterface $bind) : string
+    private function getBaseName($class, BindInterface $bind) : string
     {
         return sprintf('%s_%s', str_replace('\\', '_', $class), $bind->toString(''));
     }

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -202,7 +202,7 @@ class CompilerTest extends TestCase
         $file = file((string) (new \ReflectionClass($class))->getFileName());
         $expected = '    function returnSame(array $arrayParam, callable $callableParam)
 ';
-        $this->assertSame($expected, $file[8]);
+        $this->assertContains($expected, $file);
     }
 
     public function testNotWritable()


### PR DESCRIPTION
No more global namespace pollution.
Wrap with "namespace RayAop;" to avoid the error.

@see https://qiita.com/sasezakit/items/0a450cb194acb9dce989