### PR TITLE
fixed #108 PHP7.1 `void`関数が使えない不具合の修正

### DIFF
--- a/src/CodeGenMethod.php
+++ b/src/CodeGenMethod.php
@@ -8,6 +8,9 @@ use PhpParser\BuilderFactory;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Parser;
 use PhpParser\PrettyPrinter\Standard;
+use PhpParser\NodeAbstract;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\NullableType;
 
 final class CodeGenMethod
 {
@@ -51,7 +54,9 @@ final class CodeGenMethod
             /* @var $method \ReflectionMethod */
             $isPublic = $classMethod->flags === Class_::MODIFIER_PUBLIC;
             if ($isBindingMethod && $isPublic) {
-                $methodInsideStatements = $this->getTemplateMethodNodeStmts();
+                $methodInsideStatements = $this->getTemplateMethodNodeStmts(
+                    $classMethod->getReturnType()
+                );
                 // replace statements in the method
                 $classMethod->stmts = $methodInsideStatements;
                 $methods[] = $classMethod;
@@ -61,9 +66,12 @@ final class CodeGenMethod
         return $methods;
     }
 
-    private function getTemplateMethodNodeStmts() : array
+    /**
+     * @param null|NullableType|Identifier $returnType
+     */
+    private function getTemplateMethodNodeStmts(?NodeAbstract $returnType) : array
     {
-        $code = $this->getTemplateCode();
+        $code = $this->getTemplateCode($returnType);
         $node = $this->parser->parse($code)[0];
         if (! $node instanceof Class_) {
             throw new \LogicException; // @codeCoverageIgnore
@@ -85,10 +93,57 @@ final class CodeGenMethod
      * @see http://stackoverflow.com/questions/8343399/calling-a-function-with-explicit-parameters-vs-call-user-func-array
      * @see http://stackoverflow.com/questions/1796100/what-is-faster-many-ifs-or-else-if
      * @see http://stackoverflow.com/questions/2401478/why-is-faster-than-in-php
+     * @param null|NullableType|Identifier $returnType
      */
-    private function getTemplateCode() : string
+    private function getTemplateCode(?NodeAbstract $returnType) : string
     {
-        return /* @lang PHP */
+        /**
+         * if a void return type is specified,
+         * the function must not contain `return` statement.
+         * @see https://www.php.net/manual/en/migration71.new-features.php#migration71.new-features.void-functions
+         */
+        if ($returnType instanceof Identifier
+            && $returnType->name === 'void') {
+            return /* @lang PHP */
+            <<<'EOT'
+<?php
+class AopTemplate extends \Ray\Aop\FakeMock implements Ray\Aop\WeavedInterface
+{
+    /**
+     * @var array
+     *
+     * [$methodName => [$interceptorA[]][]
+     */
+    public $bindings;
+
+    /**
+     * @var bool
+     */
+    private $isAspect = true;
+
+    /**
+     * Method Template
+     *
+     * @param mixed $a
+     */
+    public function templateMethod($a, $b)
+    {
+        if (! $this->isAspect) {
+            $this->isAspect = true;
+
+            call_user_func_array([$this, 'parent::' . __FUNCTION__], func_get_args());
+        }
+
+        $this->isAspect = false;
+        (new Invocation($this, __FUNCTION__, func_get_args(), $this->bindings[__FUNCTION__]))->proceed();
+        $this->isAspect = true;
+    }
+}
+EOT;
+
+        }
+        else {
+            return /* @lang PHP */
             <<<'EOT'
 <?php
 class AopTemplate extends \Ray\Aop\FakeMock implements Ray\Aop\WeavedInterface
@@ -126,5 +181,6 @@ class AopTemplate extends \Ray\Aop\FakeMock implements Ray\Aop\WeavedInterface
     }
 }
 EOT;
+        }
     }
 }

--- a/src/CodeGenMethod.php
+++ b/src/CodeGenMethod.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace Ray\Aop;
 
 use PhpParser\BuilderFactory;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\Class_;
+use PhpParser\NodeAbstract;
 use PhpParser\Parser;
 use PhpParser\PrettyPrinter\Standard;
-use PhpParser\NodeAbstract;
-use PhpParser\Node\Identifier;
-use PhpParser\Node\NullableType;
 
 final class CodeGenMethod
 {
@@ -67,7 +68,7 @@ final class CodeGenMethod
     }
 
     /**
-     * @param null|NullableType|Identifier $returnType
+     * @param null|Identifier|Name|NullableType $returnType
      */
     private function getTemplateMethodNodeStmts(?NodeAbstract $returnType) : array
     {
@@ -93,11 +94,12 @@ final class CodeGenMethod
      * @see http://stackoverflow.com/questions/8343399/calling-a-function-with-explicit-parameters-vs-call-user-func-array
      * @see http://stackoverflow.com/questions/1796100/what-is-faster-many-ifs-or-else-if
      * @see http://stackoverflow.com/questions/2401478/why-is-faster-than-in-php
-     * @param null|NullableType|Identifier $returnType
+     *
+     * @param null|Identifier|Name|NullableType $returnType
      */
     private function getTemplateCode(?NodeAbstract $returnType) : string
     {
-        /**
+        /*
          * if a void return type is specified,
          * the function must not contain `return` statement.
          * @see https://www.php.net/manual/en/migration71.new-features.php#migration71.new-features.void-functions
@@ -140,10 +142,9 @@ class AopTemplate extends \Ray\Aop\FakeMock implements Ray\Aop\WeavedInterface
     }
 }
 EOT;
-
         }
-        else {
-            return /* @lang PHP */
+
+        return /* @lang PHP */
             <<<'EOT'
 <?php
 class AopTemplate extends \Ray\Aop\FakeMock implements Ray\Aop\WeavedInterface
@@ -181,6 +182,5 @@ class AopTemplate extends \Ray\Aop\FakeMock implements Ray\Aop\WeavedInterface
     }
 }
 EOT;
-        }
     }
 }

--- a/tests/CodeGenPhp71Test.php
+++ b/tests/CodeGenPhp71Test.php
@@ -29,6 +29,17 @@ class CodeGenPhp71Test extends TestCase
         $this->assertContains($expected, $code->code);
     }
 
+    /**
+     * @dataProvider returnStmtProvider
+     */
+    public function testReturnTypeVoidNotContainsReturn(string $expected)
+    {
+        $bind = new Bind;
+        $bind->bindInterceptors('returnTypeVoid', []);
+        $code = $this->codeGen->generate(new \ReflectionClass(FakePhp71NullableClass::class), $bind);
+        $this->assertNotContains($expected, $code->code);
+    }
+
     public function testReturnTypeNullable()
     {
         $bind = new Bind;
@@ -74,5 +85,17 @@ class CodeGenPhp71Test extends TestCase
         $code = $this->codeGen->generate(new \ReflectionClass(FakePhp71NullableClass::class), $bind);
         $expected = 'public function useTyped(CodeGen $codeGen)';
         $this->assertContains($expected, $code->code);
+    }
+
+    public function returnStmtProvider()
+    {
+        return [
+            'return something' => [
+                ' return ',
+            ],
+            'sole return' => [
+                ' return;',
+            ],
+        ];
     }
 }


### PR DESCRIPTION
- `return`文のない専用のテンプレートを用意
- テンプレートを出し分けるために、下記メソッドに`$returnType`引数追加
    - `CodeGenMethod@getTemplateMethodNodeStmts`
    - `CodeGenMethod@getTemplateCode`