### PR TITLE
CompilerTestにvoid関数のテストケース追加

### DIFF
--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -284,4 +284,14 @@ class CompilerTest extends TestCase
         $this->assertInstanceOf(FakeGlobalNamespaced::class, $mock);
         $this->assertSame(2, $mock->returnSame(1));
     }
+
+    public function testVoidFunction()
+    {
+        $bind = (new Bind)->bindInterceptors('returnTypeVoid', [new FakeChangeArgsInterceptor()]);
+        $compiler = new Compiler(__DIR__ . '/tmp');
+        /** @var FakePhp71NullableClass $mock */
+        $mock = $compiler->newInstance(FakePhp71NullableClass::class, [], $bind);
+        $mock->returnTypeVoid();
+        $this->assertTrue($mock->returnTypeVoidCalled);
+    }
 }

--- a/tests/Fake/FakePhp71NullableClass.php
+++ b/tests/Fake/FakePhp71NullableClass.php
@@ -7,9 +7,12 @@ use Composer\Autoload;
 
 class FakePhp71NullableClass
 {
+    public $returnTypeVoidCalled = false;
+
     public function returnTypeVoid() : void
     {
         new Autoload\ClassLoader();
+        $this->returnTypeVoidCalled = true;
     }
 
     public function returnNullable(string $str) : ?int


### PR DESCRIPTION
- 下記エラーを検出できることを確認しました:
    - void関数内に空でない`return *;`文があることによる構文エラー
    - 2eeda0869197 時点、コンパイル後のvoid関数を実行すると無限再帰となってしまう