### PR TITLE
[WIP] make AnnotationReader injectable

### DIFF
--- a/src/CodeGen.php
+++ b/src/CodeGen.php
@@ -6,6 +6,7 @@ namespace Ray\Aop;
 
 use function array_merge;
 use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\Reader as AnnotationReaderInterface;
 use function implode;
 use PhpParser\BuilderFactory;
 use PhpParser\Node\Identifier;
@@ -40,7 +41,7 @@ final class CodeGen implements CodeGenInterface
     private $codeGenMethod;
 
     /**
-     * @var AnnotationReader
+     * @var AnnotationReaderInterface
      */
     private $reader;
 
@@ -50,13 +51,14 @@ final class CodeGen implements CodeGenInterface
     public function __construct(
         Parser $parser,
         BuilderFactory $factory,
-        Standard $printer
+        Standard $printer,
+        AnnotationReaderInterface $reader = null
     ) {
         $this->parser = $parser;
         $this->factory = $factory;
         $this->printer = $printer;
         $this->codeGenMethod = new CodeGenMethod($parser, $factory, $printer);
-        $this->reader = new AnnotationReader;
+        $this->reader = $reader ?? new AnnotationReader;
     }
 
     /**

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ray\Aop;
 
 use function class_exists;
+use Doctrine\Common\Annotations\Reader as AnnotationReaderInterface;
 use PhpParser\BuilderFactory;
 use PhpParser\PrettyPrinter\Standard;
 use Ray\Aop\Exception\NotWritableException;
@@ -25,7 +26,7 @@ final class Compiler implements CompilerInterface
     /**
      * @throws \Doctrine\Common\Annotations\AnnotationException
      */
-    public function __construct(string $classDir)
+    public function __construct(string $classDir, AnnotationReaderInterface $reader = null)
     {
         if (! is_writable($classDir)) {
             throw new NotWritableException($classDir);
@@ -34,7 +35,8 @@ final class Compiler implements CompilerInterface
         $this->codeGen = new CodeGen(
             (new ParserFactory)->newInstance(),
             new BuilderFactory,
-            new Standard(['shortArraySyntax' => true])
+            new Standard(['shortArraySyntax' => true]),
+            $reader
         );
     }
 

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ray\Aop;
 
 use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\SimpleAnnotationReader;
 use FakeGlobalNamespaced;
 use function file_get_contents;
 use PHPUnit\Framework\TestCase;
@@ -302,5 +303,14 @@ class CompilerTest extends TestCase
         $compiler = new Compiler(__DIR__ . '/tmp');
         $bind = (new Bind)->bindInterceptors('foo', [new FakeDoubleInterceptor()]);
         $compiler->newInstance(FakeTwoClass::class, [], $bind);
+    }
+
+    public function testNewInstanceWithInjectedAnnotationReader()
+    {
+        $this->compiler = new Compiler(__DIR__ . '/tmp', new SimpleAnnotationReader());
+        $mock = $this->compiler->newInstance(FakeMock::class, [], $this->bind);
+        $this->assertInstanceOf(FakeMock::class, $mock);
+
+        return $mock;
     }
 }


### PR DESCRIPTION
``` php
$reader = new CachedReader(
    new AnnotationReader(),
    new ApcCache()
);

// $reader is optional.
// If null was passed, Doctrine\Common\Annotations\AnnotationReader is instantiated automatically.
$compiler = new Compiler($dir, $reader);

```