### PR TITLE
Add Weaver to segregate compiling and weaving

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -151,7 +151,16 @@ $pointcut = new Pointcut(
     [new WeekendBlocker]
 );
 $bind = (new Bind)->bind(RealBillingService::class, [$pointcut]);
-$billing = (new Compiler($tmpDir))->newInstance(RealBillingService::class, [], $bind);
+$billing = (new Weaver($bind, $tmpDir))->newInstance(RealBillingService::class, [$arg1, $arg2]);
+```
+
+## パフォーマンス
+
+`Weaver`オブジェクトはキャッシュ可能です。コンパイル、束縛、アノテーション読み込みコストを削減します。
+
+```php
+$weaver = unserialize(file_get_contentes('./serializedWever'));
+$billing = (new Weaver($bind, $tmpDir))->newInstance(RealBillingService::class, [$arg1, $arg2]);
 ```
 
 ## 優先順位

--- a/README.md
+++ b/README.md
@@ -153,7 +153,16 @@ $pointcut = new Pointcut(
     [new WeekendBlocker]
 );
 $bind = (new Bind)->bind(RealBillingService::class, [$pointcut]);
-$billing = (new Compiler($tmpDir))->newInstance(RealBillingService::class, [], $bind);
+$billing = (new Weaver($bind, $tmpDir))->newInstance(RealBillingService::class, [$arg1, $arg2]);
+```
+
+## Performance boost
+
+Cached `Weaver` object can save the compiling, binding, annotation reading costs.
+
+```php
+$weaver = unserialize(file_get_contentes('./serializedWever'));
+$billing = (new Weaver($bind, $tmpDir))->newInstance(RealBillingService::class, [$arg1, $arg2]);
 ```
 
 ## Priority

--- a/src/AopClassName.php
+++ b/src/AopClassName.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Aop;
+
+class AopClassName
+{
+    public function __invoke(string $class, string $bindName) : string
+    {
+        return sprintf('%s_%s', $class, $bindName);
+    }
+}

--- a/src/Bind.php
+++ b/src/Bind.php
@@ -26,6 +26,11 @@ final class Bind implements BindInterface
         $this->reader = new AnnotationReader();
     }
 
+    public function __sleep()
+    {
+        return ['bindings'];
+    }
+
     /**
      * {@inheritdoc}
      *

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -55,7 +55,8 @@ final class Compiler implements CompilerInterface
      * {@inheritdoc}
      *
      * @throws \ReflectionException
-     * @deprecated Use Weaver:newInstance() inst
+     * 
+     * @deprecated Use Weaver:newInstance() instead
      */
     public function newInstance(string $class, array $args, BindInterface $bind)
     {

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -55,6 +55,7 @@ final class Compiler implements CompilerInterface
      * {@inheritdoc}
      *
      * @throws \ReflectionException
+     * @deprecated Use Weaver:newInstance() inst
      */
     public function newInstance(string $class, array $args, BindInterface $bind)
     {

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -55,7 +55,7 @@ final class Compiler implements CompilerInterface
      * {@inheritdoc}
      *
      * @throws \ReflectionException
-     * 
+     *
      * @deprecated Use Weaver:newInstance() instead
      */
     public function newInstance(string $class, array $args, BindInterface $bind)

--- a/src/Weaver.php
+++ b/src/Weaver.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Aop;
+
+final class Weaver
+{
+    /**
+     * @var BindInterface
+     */
+    private $bind;
+
+    /**
+     * @var string
+     */
+    private $bindName;
+
+    /**
+     * @var string
+     */
+    private $classDir;
+
+    /**
+     * @var AopClassName
+     */
+    private $aopClassName;
+
+    public function __construct(BindInterface $bind, string $classDir)
+    {
+        $this->bind = $bind;
+        $this->bindName = $bind->toString('');
+        $this->compiler = new Compiler($classDir);
+        $this->classDir = $classDir;
+        $this->aopClassName = new AopClassName;
+        $this->regsterLoader();
+    }
+
+    public function __wakeup()
+    {
+        $this->regsterLoader();
+    }
+
+    public function newInstance(string $class, array $args)
+    {
+        $aopClass = ($this->aopClassName)($class, $this->bindName);
+        if (! class_exists($aopClass)) {
+            $this->compiler->compile($class, $this->bind);
+            assert(class_exists($aopClass));
+        }
+        $instance = (new ReflectionClass($aopClass))->newInstanceArgs($args);
+        $instance->bindings = $this->bind->getBindings();
+
+        return $instance;
+    }
+
+    private function regsterLoader()
+    {
+        spl_autoload_register(
+            function (string $class) {
+                $file = sprintf('%s/%s.php', $this->classDir, str_replace('\\', '_', $class));
+                if (file_exists($file)) {
+                    include $file; //@codeCoverageIgnore
+                }
+            }
+        );
+    }
+}

--- a/src/Weaver.php
+++ b/src/Weaver.php
@@ -27,6 +27,11 @@ final class Weaver
     private $aopClassName;
 
     /**
+     * @var string[]
+     */
+    private static $classDirs = [];
+
+    /**
      * @var Compiler
      */
     private $compiler;
@@ -61,6 +66,10 @@ final class Weaver
 
     private function regsterLoader()
     {
+        if (\in_array($this->classDir, static::$classDirs, true)) {
+            return;
+        }
+        static::$classDirs[] = $this->classDir;
         spl_autoload_register(
             function (string $class) {
                 $file = sprintf('%s/%s.php', $this->classDir, str_replace('\\', '_', $class));

--- a/src/Weaver.php
+++ b/src/Weaver.php
@@ -60,13 +60,14 @@ final class Weaver
         return $instance;
     }
 
-    public function weave(string $class): string
+    public function weave(string $class) : string
     {
         $aopClass = ($this->aopClassName)($class, $this->bindName);
-        if (!class_exists($aopClass)) {
+        if (! class_exists($aopClass)) {
             $this->compiler->compile($class, $this->bind);
             assert(class_exists($aopClass));
         }
+
         return $aopClass;
     }
 

--- a/src/Weaver.php
+++ b/src/Weaver.php
@@ -48,15 +48,21 @@ final class Weaver
 
     public function newInstance(string $class, array $args)
     {
-        $aopClass = ($this->aopClassName)($class, $this->bindName);
-        if (! class_exists($aopClass)) {
-            $this->compiler->compile($class, $this->bind);
-            assert(class_exists($aopClass));
-        }
+        $aopClass = $this->weave($class);
         $instance = (new ReflectionClass($aopClass))->newInstanceArgs($args);
         $instance->bindings = $this->bind->getBindings();
 
         return $instance;
+    }
+
+    public function weave(string $class): string
+    {
+        $aopClass = ($this->aopClassName)($class, $this->bindName);
+        if (!class_exists($aopClass)) {
+            $this->compiler->compile($class, $this->bind);
+            assert(class_exists($aopClass));
+        }
+        return $aopClass;
     }
 
     private function regsterLoader()

--- a/src/Weaver.php
+++ b/src/Weaver.php
@@ -55,13 +55,14 @@ final class Weaver
         return $instance;
     }
 
-    public function weave(string $class): string
+    public function weave(string $class) : string
     {
         $aopClass = ($this->aopClassName)($class, $this->bindName);
-        if (!class_exists($aopClass)) {
+        if (! class_exists($aopClass)) {
             $this->compiler->compile($class, $this->bind);
             assert(class_exists($aopClass));
         }
+
         return $aopClass;
     }
 

--- a/src/Weaver.php
+++ b/src/Weaver.php
@@ -26,6 +26,11 @@ final class Weaver
      */
     private $aopClassName;
 
+    /**
+     * @var Compiler
+     */
+    private $compiler;
+
     public function __construct(BindInterface $bind, string $classDir)
     {
         $this->bind = $bind;

--- a/src/Weaver.php
+++ b/src/Weaver.php
@@ -53,15 +53,21 @@ final class Weaver
 
     public function newInstance(string $class, array $args)
     {
-        $aopClass = ($this->aopClassName)($class, $this->bindName);
-        if (! class_exists($aopClass)) {
-            $this->compiler->compile($class, $this->bind);
-            assert(class_exists($aopClass));
-        }
+        $aopClass = $this->weave($class);
         $instance = (new ReflectionClass($aopClass))->newInstanceArgs($args);
         $instance->bindings = $this->bind->getBindings();
 
         return $instance;
+    }
+
+    public function weave(string $class): string
+    {
+        $aopClass = ($this->aopClassName)($class, $this->bindName);
+        if (!class_exists($aopClass)) {
+            $this->compiler->compile($class, $this->bind);
+            assert(class_exists($aopClass));
+        }
+        return $aopClass;
     }
 
     private function regsterLoader()

--- a/tests/WeaverTest.php
+++ b/tests/WeaverTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Aop;
+
+use PHPUnit\Framework\TestCase;
+
+class WeaverTest extends TestCase
+{
+    public function test__construct()
+    {
+        $matcher = new Matcher;
+        $pointcut = new Pointcut($matcher->any(), $matcher->startsWith('return'), [new FakeDoubleInterceptor]);
+        $bind = (new Bind)->bind(FakeMock::class, [$pointcut]);
+        $weaver = new Weaver($bind, __DIR__ . '/tmp');
+        $this->assertInstanceOf(Weaver::class, $weaver);
+
+        return $weaver;
+    }
+
+    /**
+     * @depends test__construct
+     */
+    public function testNewInstance(Weaver $weaver)
+    {
+        $weaved = $weaver->newInstance(FakeMock::class, []);
+        $result = $weaved->returnSame(1);
+        $this->assertSame(2, $result);
+    }
+
+    /**
+     * @depends test__construct
+     */
+    public function testCachedWeaver(Weaver $weaver)
+    {
+        $weaver = unserialize(serialize($weaver));
+        $weaved = $weaver->newInstance(FakeMock::class, []);
+        $result = $weaved->returnSame(1);
+        $this->assertSame(2, $result);
+    }
+}

--- a/tests/WeaverTest.php
+++ b/tests/WeaverTest.php
@@ -22,6 +22,15 @@ class WeaverTest extends TestCase
     /**
      * @depends test__construct
      */
+    public function testWeave(Weaver $weaver)
+    {
+        $className = $weaver->weave(FakeMock::class);
+        $this->assertTrue(\class_exists($className, false));
+    }
+
+    /**
+     * @depends test__construct
+     */
     public function testNewInstance(Weaver $weaver)
     {
         $weaved = $weaver->newInstance(FakeMock::class, []);


### PR DESCRIPTION
Serializable new `Weaver` boost the performance.

 * Save binding procedure cost
 * Save binding hash `$binding->toString()` cost
 * Reuse compiled AOP class
 * Register autoloader

```php
$matcher = new Matcher;
$pointcut = new Pointcut($matcher->any(), $matcher->startsWith('return'), [new FakeDoubleInterceptor]);
$bind = (new Bind)->bind(FakeMock::class, [$pointcut]);
$weaver = new Weaver($bind, __DIR__ . '/tmp'); // serializable

$instance = $weaver->newInstance(FakeMock::class, [$constructorArg1]);
```

* `Compiler::newInstance()` is deprecated.