### PR TITLE
make Bind::$reader injectable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "nikic/php-parser": "^4.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^7.5",
+        "mockery/mockery": "^1.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Bind.php
+++ b/src/Bind.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ray\Aop;
 
 use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\Reader as AnnotationReaderInterface;
 
 final class Bind implements BindInterface
 {
@@ -14,16 +15,18 @@ final class Bind implements BindInterface
     private $bindings = [];
 
     /**
-     * @var AnnotationReader
+     * @var AnnotationReaderInterface
      */
     private $reader;
 
     /**
+     * @param AnnotationReaderInterface|null $reader
+     *
      * @throws \Doctrine\Common\Annotations\AnnotationException
      */
-    public function __construct()
+    public function __construct(AnnotationReaderInterface $reader = null)
     {
-        $this->reader = new AnnotationReader();
+        $this->reader = $reader ?? new AnnotationReader();
     }
 
     /**

--- a/tests/BindTest.php
+++ b/tests/BindTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Ray\Aop;
 
+use Doctrine\Common\Annotations\SimpleAnnotationReader;
 use PHPUnit\Framework\TestCase;
 use Ray\Aop\Annotation\FakeMarker;
 use Ray\Aop\Annotation\FakeMarker2;
@@ -114,5 +115,17 @@ class BindTest extends TestCase
             'getDouble' => [$onion4, $onion3, $onion2, $onion1]
         ];
         $this->assertSame($expect, $actual);
+    }
+
+    public function testBindWithInjectedAnnotationReader()
+    {
+        $reader = \Mockery::spy(new SimpleAnnotationReader());
+        $bind = new Bind($reader);
+        $interceptors = [new FakeDoubleInterceptor];
+        $pointcut = new Pointcut((new Matcher)->startsWith('Ray'), (new Matcher)->startsWith('get'), $interceptors);
+        $bind->bind(FakeAnnotateClass::class, [$pointcut]);
+        $this->assertArrayHasKey('getDouble', $bind->getBindings());
+        $this->assertSame($bind->getBindings()['getDouble'], $interceptors);
+        $reader->shouldHaveReceived('getMethodAnnotations');
     }
 }


### PR DESCRIPTION
Even if #117 is merged, ```Bind``` keep calling  ```AnnotationReader::getMethodAnnotations()``` each time. This can be optimized by using ```CachedReader```.