### PR TITLE
Update annotation cache detection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,10 +42,10 @@ jobs:
   - stage: Code Quality
     name: Static analysis
     php: 7.2
-    install: composer require --dev phpstan/phpstan ^0.12 vimeo/psalm ^3.8;
+    install: composer global require --dev phpstan/phpstan ^0.12 vimeo/psalm ^3.11;
     script:
-      - ./vendor/bin/phpstan analyse -c phpstan.neon --no-progress --no-interaction;
-      - ./vendor/bin/psalm --shepherd --stats;
+      - ~/.composer/vendor/bin/phpstan analyse -c phpstan.neon --no-progress --no-interaction;
+      - ~/.composer/vendor/bin/psalm --show-info=false
 
   - stage: Code Quality
     name: Coding standards

--- a/demo/benchmark.php
+++ b/demo/benchmark.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-namespace Ray\Aop\Demo;
-
 require __DIR__ . '/bootstrap.php';
 require __DIR__ . '/src/FooClass_Optimized.php';
 

--- a/src/ReflectionClass.php
+++ b/src/ReflectionClass.php
@@ -27,10 +27,8 @@ class ReflectionClass extends \ReflectionClass implements Reader
     public function getAnnotations() : array
     {
         $object = $this->object;
-        if ($object instanceof WeavedInterface) {
-            assert(property_exists($object, 'classAnnotations'));
-
-            return unserialize($object->classAnnotations);
+        if (isset($object->annotations)) {
+            return unserialize($object->classAnnotations); // @phpstan-ignore-line
         }
 
         return (new AnnotationReader)->getClassAnnotations(new \ReflectionClass($this->name));

--- a/src/ReflectionMethod.php
+++ b/src/ReflectionMethod.php
@@ -53,11 +53,10 @@ final class ReflectionMethod extends \ReflectionMethod implements Reader
     public function getAnnotations() : array
     {
         $object = $this->object;
-        if (! $object instanceof WeavedInterface) {
+        if (! isset($object->annotations)) {
             return (new AnnotationReader)->getMethodAnnotations(new \ReflectionMethod($this->class, $this->name));
         }
-        assert(isset($object->methodAnnotations));
-        $annotations = unserialize($object->methodAnnotations);
+        $annotations = unserialize($object->methodAnnotations); // @phpstan-ignore-line
         if (array_key_exists($this->method, $annotations)) {
             return $annotations[$this->method];
         }


### PR DESCRIPTION
Users sometimes create Weaved classes without annotation cache for testing. This is the edge case. 