### PR TITLE
change getNamedArguments return-type

### DIFF
--- a/src/Invocation.php
+++ b/src/Invocation.php
@@ -23,7 +23,7 @@ interface Invocation extends Joinpoint
     /**
      * Get the named arguments as an array object.
      *
-     * @return \ArrayObject<array, array> the argument of the invocation  [`paramName1'=>'arg1', `paramName2'=>'arg2']
+     * @return \ArrayObject<int|string, string> the argument of the invocation  [`paramName1'=>'arg1', `paramName2'=>'arg2']
      */
     public function getNamedArguments() : \ArrayObject;
 }


### PR DESCRIPTION
getArguments has a return-type ArrayObejct<int, string>
but getNamedArguments has a return-type ArrayObejct<array, array>

if getNamedArguments function returns value like `['paramName1'=>'arg1', 'paramName2'=>'arg2']`, phpstan/psalm return some errors.

https://psalm.dev/docs/annotating_code/type_syntax/object_types/