### PR TITLE
Fix #141

### DIFF
--- a/src/Invocation.php
+++ b/src/Invocation.php
@@ -16,14 +16,14 @@ interface Invocation extends Joinpoint
     /**
      * Get the arguments as an array object.
      *
-     * @return \ArrayObject<int, string> the argument of the invocation ['arg1', 'arg2']
+     * @return \ArrayObject<int, scalar> the argument of the invocation ['arg1', 'arg2']
      */
     public function getArguments() : \ArrayObject;
 
     /**
      * Get the named arguments as an array object.
      *
-     * @return \ArrayObject<int|string, string> the argument of the invocation  [`paramName1'=>'arg1', `paramName2'=>'arg2']
+     * @return \ArrayObject<string, scalar> the argument of the invocation  [`paramName1'=>'arg1', `paramName2'=>'arg2']
      */
     public function getNamedArguments() : \ArrayObject;
 }

--- a/src/ReflectiveMethodInvocation.php
+++ b/src/ReflectiveMethodInvocation.php
@@ -33,7 +33,7 @@ final class ReflectiveMethodInvocation implements MethodInvocation
 
     /**
      * @param MethodInterceptor[] $interceptors
-     * @param array<int, mixed>   $arguments
+     * @param array<int, scalar>  $arguments
      */
     public function __construct(
         object $object,


### PR DESCRIPTION
It returns not only `string` but all `scalar` value.

Triggered an error at https://travis-ci.org/github/bearsunday/BEAR.Resource/jobs/690441999