### PR TITLE
Remove unnecessary "class_exists" call

### DIFF
--- a/src/Code.php
+++ b/src/Code.php
@@ -8,7 +8,6 @@ use PhpParser\Node;
 use PhpParser\PrettyPrinter\Standard;
 use Ray\Aop\Exception\NotWritableException;
 
-use function class_exists;
 use function dirname;
 use function file_put_contents;
 use function is_string;
@@ -33,7 +32,6 @@ final class Code
 
     public function save(string $classDir, string $aopClassName): string
     {
-        class_exists($aopClassName);
         $flatName = str_replace('\\', '_', $aopClassName);
         $filename = sprintf('%s/%s.php', $classDir, $flatName);
         $tmpFile = tempnam(dirname($filename), 'swap');


### PR DESCRIPTION
This unnessary `class_exists` triggers the autoloader and leads to unexpected problems caused by poor quality autoloaders.