### PR TITLE
slove code  issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /coverage.xml
 /vendor-bin/**/vendor
 /.phpunit-cache
+.idea

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -86,8 +86,8 @@ final class Compiler implements CompilerInterface
         if ($this->hasNoBinding($class, $bind)) {
             return $class;
         }
-
-        $aopClassName = ($this->aopClassName)($class, $bind->toString(''));
+        $classReflection = new ReflectionClass($class);
+        $aopClassName = sprintf('%s_%s', $class, filemtime($classReflection->getFileName()));
         if (class_exists($aopClassName, false)) {
             return $aopClassName;
         }
@@ -128,6 +128,7 @@ final class Compiler implements CompilerInterface
      */
     private function requireFile(string $aopClassName, \ReflectionClass $sourceClass, BindInterface $bind): void
     {
+        array_map('unlink', glob($this->classDir . '/' . preg_replace('/\\\/', '_', $sourceClass->name) . '_*.php'));
         $code = $this->codeGen->generate($sourceClass, $bind);
         $file = $code->save($this->classDir, $aopClassName);
         assert(file_exists($file));


### PR DESCRIPTION
This request solves 2 problems
First, prevent unlimited generation of temporary class files. Ensure that one source code file corresponds to one generated file.
Secondly, 1 bug was solved.
When the method of the source code is bound, there is a `Declaration` error when the parameter is added or modified.
`@RequestMapping` is bound with aop.
```php
    /**
     * @RequestMapping(name="test",path="/test",method="GET")
     */
    public function test()
    {
        return 'hello,hll1';
    }

    /**
     * @RequestMapping(name="add",path="/add",method="GET")
     * @LoginRequired
     */
    public function add4343(GoodsQuery $goodsQuery)
    {
        return 'hello,add';
    }
```
The corresponding file generated is `Mall_Api_Controller_IndexCtrller_2956060156.php`

Change the source code to
```php
   /**
      * @RequestMapping(name="test",path="/test",method="GET")
      */
     public function test()
     {
         return'hello,hll1';
     }

     /**
      * @RequestMapping(name="test",path="/add",method="GET")
      * @LoginRequired
      */
     public function add4343()
     {
         return'hello,add';
     }
```
No new files will be generated.

We will get error

`Declaration of Mall\Api\Controller\IndexCtrller_2956060156::add4343(Mall\Api\Controller\RequestMapper\GoodsQuery $goodsQuery) should be compatible with Mall\Api\Controller\IndexCtrller::add4343()`
