### PR TITLE
Parent method intercept

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "psr-4": {
             "Ray\\Aop\\": ["tests/", "tests/Fake/"]
         },
-        "files": ["tests/Fake/FakeGlobalNamespaced.php"]
+        "files": ["tests/Fake/FakeGlobalNamespaced.php", "tests/Fake/FakeGlobalEmptyNamespaced.php"]
     },
     "suggest": {
         "ray/di": "A dependency injection framework"

--- a/src/AopClass.php
+++ b/src/AopClass.php
@@ -44,7 +44,7 @@ final class AopClass
     public function __invoke(CodeVisitor $visitor, ReflectionClass $sourceClass, BindInterface $bind): Class_
     {
         assert($visitor->class instanceof Class_);
-        $methods = $this->codeGenMethod->getMethods($bind, $visitor);
+        $methods = $this->codeGenMethod->getMethods($sourceClass, $bind, $visitor);
         $propStms = ($this->aopProps)($sourceClass);
         $classStm = $visitor->class;
         $newClassName = ($this->aopClassName)((string) $visitor->class->name, $bind->toString(''));

--- a/src/CodeGenMethod.php
+++ b/src/CodeGenMethod.php
@@ -72,6 +72,9 @@ final class CodeGenMethod
         return new ReflectionClass($className);
     }
 
+   /**
+    * @return class-string
+    */
     private function getClassName(CodeVisitor $code): string
     {
         assert($code->class instanceof Class_);

--- a/src/CodeGenMethod.php
+++ b/src/CodeGenMethod.php
@@ -19,6 +19,7 @@ use function assert;
 use function class_exists;
 use function in_array;
 
+/** @SuppressWarnings(PHPMD.CouplingBetweenObjects) */
 final class CodeGenMethod
 {
     /** @var Parser */

--- a/src/CodeGenMethod.php
+++ b/src/CodeGenMethod.php
@@ -65,9 +65,6 @@ final class CodeGenMethod
     private function getReflectionClass(CodeVisitor $code): ReflectionClass
     {
         $className = $this->getClassName($code);
-        if (! class_exists($className)) {
-            throw new InvalidSourceClassException($className); // @codeCoverageIgnore
-        }
 
         return new ReflectionClass($className);
     }
@@ -82,12 +79,13 @@ final class CodeGenMethod
 
         $className = $code->class->name->name;
         $namespace = $this->getNamespace($code);
+        $classString = $namespace === null ? $className : $namespace . '\\' . $className;
 
-        if ($namespace === null) {
-            return $className;
+        if (! class_exists($classString)) {
+            throw new InvalidSourceClassException($classString); // @codeCoverageIgnore
         }
 
-        return $namespace . '\\' . $className;
+        return $classString;
     }
 
     private function getNamespace(CodeVisitor $code): ?string

--- a/src/CodeGenMethod.php
+++ b/src/CodeGenMethod.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Ray\Aop;
 
-use Doctrine\Common\Annotations\AnnotationException;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Class_;
@@ -28,9 +27,6 @@ final class CodeGenMethod
     /** @var VisitorFactory */
     private $visitorFactory;
 
-    /**
-     * @throws AnnotationException
-     */
     public function __construct(
         Parser $parser
     ) {

--- a/src/CodeGenMethod.php
+++ b/src/CodeGenMethod.php
@@ -129,8 +129,9 @@ final class CodeGenMethod
         ReflectionMethod $bindingMethod,
         CodeVisitor $code
     ): ClassMethod {
+        $bindingMethodName = $bindingMethod->getName();
         foreach ($code->classMethod as $classMethod) {
-            if ($classMethod->name->name === $bindingMethod->getName()) {
+            if ($classMethod->name->name === $bindingMethodName) {
                 return $classMethod;
             }
         }

--- a/src/CodeGenMethod.php
+++ b/src/CodeGenMethod.php
@@ -16,7 +16,6 @@ use ReflectionMethod;
 
 use function array_keys;
 use function assert;
-use function class_exists;
 use function in_array;
 
 /** @SuppressWarnings(PHPMD.CouplingBetweenObjects) */
@@ -36,12 +35,13 @@ final class CodeGenMethod
     }
 
     /**
+     * @param ReflectionClass<object> $reflectionClass
+     *
      * @return ClassMethod[]
      */
-    public function getMethods(BindInterface $bind, CodeVisitor $code): array
+    public function getMethods(ReflectionClass $reflectionClass, BindInterface $bind, CodeVisitor $code): array
     {
         $bindingMethods = array_keys($bind->getBindings());
-        $reflectionClass = $this->getReflectionClass($code);
         $reflectionMethods = $reflectionClass->getMethods(ReflectionMethod::IS_PUBLIC);
         $methods = [];
         foreach ($reflectionMethods as $reflectionMethod) {
@@ -59,47 +59,6 @@ final class CodeGenMethod
         }
 
         return $methods;
-    }
-
-    /** @return ReflectionClass<object>  */
-    private function getReflectionClass(CodeVisitor $code): ReflectionClass
-    {
-        $className = $this->getClassName($code);
-
-        return new ReflectionClass($className);
-    }
-
-   /**
-    * @return class-string
-    */
-    private function getClassName(CodeVisitor $code): string
-    {
-        assert($code->class instanceof Class_);
-        assert($code->class->name instanceof Identifier);
-
-        $className = $code->class->name->name;
-        $namespace = $this->getNamespace($code);
-        $classString = $namespace === null ? $className : $namespace . '\\' . $className;
-
-        if (! class_exists($classString)) {
-            throw new InvalidSourceClassException($classString); // @codeCoverageIgnore
-        }
-
-        return $classString;
-    }
-
-    private function getNamespace(CodeVisitor $code): ?string
-    {
-        if ($code->namespace === null) {
-            return null;
-        }
-
-        $namespace = $code->namespace->name;
-        if ($namespace === null) {
-            return null;
-        }
-
-        return $namespace->toString();
     }
 
     /**

--- a/tests/Fake/FakeGlobalEmptyNamespaced.php
+++ b/tests/Fake/FakeGlobalEmptyNamespaced.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+    /** doc comment of FakeMock */
+    class FakeGlobalEmptyNamespaced
+    {
+        /**
+         * doc comment of returnSame
+         */
+        public function returnSame($a)
+        {
+            return $a;
+        }
+    }
+}

--- a/tests/Fake/FakeMockChild.php
+++ b/tests/Fake/FakeMockChild.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Aop;
+
+class FakeMockChild extends FakeMock
+{
+
+}

--- a/tests/Fake/FakeMockChild.php
+++ b/tests/Fake/FakeMockChild.php
@@ -6,5 +6,4 @@ namespace Ray\Aop;
 
 class FakeMockChild extends FakeMock
 {
-
 }

--- a/tests/Fake/FakeMockChildChild.php
+++ b/tests/Fake/FakeMockChildChild.php
@@ -6,5 +6,4 @@ namespace Ray\Aop;
 
 class FakeMockChildChild extends FakeMockChild
 {
-
 }

--- a/tests/Fake/FakeMockChildChild.php
+++ b/tests/Fake/FakeMockChildChild.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Aop;
+
+class FakeMockChildChild extends FakeMockChild
+{
+
+}

--- a/tests/tmp_unerase/Ray_Aop_FakeWeaverMock_970308000.php
+++ b/tests/tmp_unerase/Ray_Aop_FakeWeaverMock_970308000.php
@@ -1,0 +1,66 @@
+<?php
+
+declare (strict_types=1);
+namespace Ray\Aop;
+
+use Ray\Aop\WeavedInterface;
+use Ray\Aop\ReflectiveMethodInvocation as Invocation;
+/** doc comment of FakeMock */
+class FakeWeaverMock_970308000 extends \Ray\Aop\FakeWeaverMock implements WeavedInterface
+{
+    public $bind;
+    public $bindings = [];
+    public $methodAnnotations = 'a:0:{}';
+    public $classAnnotations = 'a:0:{}';
+    private $isAspect = true;
+    /**
+     * doc comment of returnSame
+     */
+    public function returnSame($a)
+    {
+        if (!$this->isAspect) {
+            $this->isAspect = true;
+            call_user_func_array([$this, 'parent::' . __FUNCTION__], func_get_args());
+            return;
+        }
+        $this->isAspect = false;
+        (new Invocation($this, __FUNCTION__, func_get_args(), $this->bindings[__FUNCTION__]))->proceed();
+        $this->isAspect = true;
+    }
+    /**
+     * doc comment of getSub
+     */
+    public function getSub($a, $b)
+    {
+        if (!$this->isAspect) {
+            $this->isAspect = true;
+            call_user_func_array([$this, 'parent::' . __FUNCTION__], func_get_args());
+            return;
+        }
+        $this->isAspect = false;
+        (new Invocation($this, __FUNCTION__, func_get_args(), $this->bindings[__FUNCTION__]))->proceed();
+        $this->isAspect = true;
+    }
+    public function returnValue(?FakeNum $num = null)
+    {
+        if (!$this->isAspect) {
+            $this->isAspect = true;
+            call_user_func_array([$this, 'parent::' . __FUNCTION__], func_get_args());
+            return;
+        }
+        $this->isAspect = false;
+        (new Invocation($this, __FUNCTION__, func_get_args(), $this->bindings[__FUNCTION__]))->proceed();
+        $this->isAspect = true;
+    }
+    public function getPrivateVal()
+    {
+        if (!$this->isAspect) {
+            $this->isAspect = true;
+            call_user_func_array([$this, 'parent::' . __FUNCTION__], func_get_args());
+            return;
+        }
+        $this->isAspect = false;
+        (new Invocation($this, __FUNCTION__, func_get_args(), $this->bindings[__FUNCTION__]))->proceed();
+        $this->isAspect = true;
+    }
+}


### PR DESCRIPTION
When the following `class B` is compiled, `echo` method could not be intercepted.

```PHP

// A.php
class A
{
    public function echo(): void
    {
        echo 'echo';
    }
}

// B.php
class B extends A
{
}

// run.php
require __DIR__ . '/bootstrap.php';

$compiler = new Ray\Aop\Compiler(__DIR__ . '/tmp');
$bind = (new Ray\Aop\Bind())->bindInterceptors('echo', [new Ray\Aop\NullInterceptor()]);
$b = $compiler->newInstance(Ray\Aop\Demo\B::class, [], $bind);

// generated class
<?php

declare (strict_types=1);
namespace Ray\Aop\Demo;

use Ray\Aop\WeavedInterface;
use Ray\Aop\ReflectiveMethodInvocation as Invocation;
class B_1599363031 extends \Ray\Aop\Demo\B implements WeavedInterface
{
    public $bind;
    public $bindings = [];
    public $methodAnnotations = 'a:0:{}';
    public $classAnnotations = 'a:0:{}';
    private $isAspect = true;
}
```

In this PR, the following class is generated

```PHP
<?php

declare (strict_types=1);
namespace Ray\Aop\Demo;

use Ray\Aop\WeavedInterface;
use Ray\Aop\ReflectiveMethodInvocation as Invocation;
class B_1599363031 extends \Ray\Aop\Demo\B implements WeavedInterface
{
    public $bind;
    public $bindings = [];
    public $methodAnnotations = 'a:0:{}';
    public $classAnnotations = 'a:0:{}';
    private $isAspect = true;
    public function echo() : void
    {
        if (!$this->isAspect) {
            $this->isAspect = true;
            call_user_func_array([$this, 'parent::' . __FUNCTION__], func_get_args());
            return;
        }
        $this->isAspect = false;
        (new Invocation($this, __FUNCTION__, func_get_args(), $this->bindings[__FUNCTION__]))->proceed();
        $this->isAspect = true;
    }
}
```