### PR TITLE
New functionality

### DIFF
--- a/src/Annotation/AllPublicMethods.php
+++ b/src/Annotation/AllPublicMethods.php
@@ -14,9 +14,7 @@ use Attribute;
 class AllPublicMethods
 {
     private bool $allMethods = true;
-    /**
-     * @return bool
-     */
+
     final public function isAllMethods(): bool
     {
         return $this->allMethods;

--- a/src/Annotation/AllPublicMethods.php
+++ b/src/Annotation/AllPublicMethods.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Aop\Annotation;
+
+use Attribute;
+
+/**
+ * @Annotation
+ * @Target("ALL")
+ */
+#[Attribute(Attribute::TARGET_ALL)]
+class AllPublicMethods
+{
+    private bool $allMethods = true;
+    /**
+     * @return bool
+     */
+    final public function isAllMethods(): bool
+    {
+        return $this->allMethods;
+    }
+}

--- a/src/Bind.php
+++ b/src/Bind.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Ray\Aop;
 
 use Doctrine\Common\Annotations\AnnotationException;
+use ReflectionAttribute;
 use ReflectionClass;
 
 use function array_key_exists;
 use function array_merge;
+use function method_exists;
 use function serialize;
 
 final class Bind implements BindInterface
@@ -102,13 +104,18 @@ final class Bind implements BindInterface
         return $keyPointcuts;
     }
 
-
+    /**
+     * @param Pointcut[] $pointcuts
+     */
     private function checkAttributeInClass(ReflectionClass $class, array $pointcuts): bool
     {
         foreach ($class->getAttributes() as $attribute) {
-            if ($attribute->getName() === key($pointcuts) &&
-                method_exists($attribute->newInstance(),'isAllMethods') &&
-                $attribute->newInstance()->isAllMethods()) {
+            if (
+                $attribute instanceof ReflectionAttribute
+                && array_key_exists($attribute->getName(), $pointcuts)
+                && method_exists($attribute->newInstance(), 'isAllMethods')
+                && $attribute->newInstance()->isAllMethods()
+            ) {
                 return true;
             }
         }

--- a/src/Bind.php
+++ b/src/Bind.php
@@ -106,7 +106,6 @@ final class Bind implements BindInterface
     private function checkAttributeInClass(ReflectionClass $class, array $pointcuts): bool
     {
         foreach ($class->getAttributes() as $attribute) {
-            var_dump($attribute->getName());
             if ($attribute->getName() === key($pointcuts) &&
                 method_exists($attribute->newInstance(),'isAllMethods') &&
                 $attribute->newInstance()->isAllMethods()) {

--- a/src/Bind.php
+++ b/src/Bind.php
@@ -42,6 +42,8 @@ final class Bind implements BindInterface
     {
         $pointcuts = $this->getAnnotationPointcuts($pointcuts);
         $class = new ReflectionClass($class);
+        $atributeIsClass = $this->checkAttributeInClass($class, $pointcuts);
+        $this->methodMatch->setAtributeIsClass($atributeIsClass);
         $methods = $class->getMethods(ReflectionMethod::IS_PUBLIC);
         foreach ($methods as $method) {
             ($this->methodMatch)($class, $method, $pointcuts);
@@ -98,5 +100,17 @@ final class Bind implements BindInterface
         }
 
         return $keyPointcuts;
+    }
+
+
+    private function checkAttributeInClass(ReflectionClass $class, array $pointcuts): bool
+    {
+        foreach ($class->getAttributes() as $attribute) {
+            if ($attribute->getName() === key($pointcuts)) {
+                return true;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/Bind.php
+++ b/src/Bind.php
@@ -106,11 +106,14 @@ final class Bind implements BindInterface
     private function checkAttributeInClass(ReflectionClass $class, array $pointcuts): bool
     {
         foreach ($class->getAttributes() as $attribute) {
-            if ($attribute->getName() === key($pointcuts)) {
+            var_dump($attribute->getName());
+            if ($attribute->getName() === key($pointcuts) &&
+                method_exists($attribute->newInstance(),'isAllMethods') &&
+                $attribute->newInstance()->isAllMethods()) {
                 return true;
             }
         }
 
-        return true;
+        return false;
     }
 }

--- a/src/MethodMatch.php
+++ b/src/MethodMatch.php
@@ -11,6 +11,7 @@ use ReflectionMethod;
 
 use function array_key_exists;
 use function get_class;
+use function str_starts_with;
 
 final class MethodMatch
 {
@@ -20,7 +21,8 @@ final class MethodMatch
     /** @var BindInterface */
     private $bind;
 
-    private bool $attributeIsClass = false;
+    /** @var bool */
+    private $attributeIsClass = false;
 
     public function __construct(BindInterface $bind)
     {
@@ -58,7 +60,7 @@ final class MethodMatch
     private function annotatedMethodMatchBind(ReflectionClass $class, ReflectionMethod $method, Pointcut $pointCut): void
     {
         $isMethodMatch = $pointCut->methodMatcher->matchesMethod($method, $pointCut->methodMatcher->getArguments());
-        if ((!$isMethodMatch && !$this->attributeIsClass) || str_starts_with($method->name, '__construct')) {
+        if ((! $isMethodMatch && ! $this->attributeIsClass) || str_starts_with($method->name, '__construct')) {
             return;
         }
 

--- a/src/MethodMatch.php
+++ b/src/MethodMatch.php
@@ -20,6 +20,8 @@ final class MethodMatch
     /** @var BindInterface */
     private $bind;
 
+    private bool $attributeIsClass = false;
+
     public function __construct(BindInterface $bind)
     {
         $this->bind = $bind;
@@ -56,7 +58,7 @@ final class MethodMatch
     private function annotatedMethodMatchBind(ReflectionClass $class, ReflectionMethod $method, Pointcut $pointCut): void
     {
         $isMethodMatch = $pointCut->methodMatcher->matchesMethod($method, $pointCut->methodMatcher->getArguments());
-        if (! $isMethodMatch) {
+        if ((!$isMethodMatch && !$this->attributeIsClass) || str_starts_with($method->name, '__construct')) {
             return;
         }
 
@@ -93,5 +95,10 @@ final class MethodMatch
         }
 
         return $pointcuts;
+    }
+
+    public function setAtributeIsClass(bool $atributeIsClass): void
+    {
+        $this->attributeIsClass = $atributeIsClass;
     }
 }

--- a/tests/BindTest.php
+++ b/tests/BindTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ray\Aop;
 
 use PHPUnit\Framework\TestCase;
+use Ray\Aop\Annotation\FakeAllPublicMethods;
 use Ray\Aop\Annotation\FakeMarker;
 use Ray\Aop\Annotation\FakeMarker2;
 use Ray\Aop\Annotation\FakeMarker3;
@@ -108,6 +109,19 @@ class BindTest extends TestCase
         $actual = $this->bind->getBindings();
         $expect = [
             'getDouble' => [$onion4, $onion3, $onion2, $onion1],
+        ];
+        $this->assertSame($expect, $actual);
+    }
+
+    public function testAllPublicMethodsAnnotation(): void
+    {
+        $onion1 = new FakeOnionInterceptor1();
+        $pointcut1 = new Pointcut((new Matcher())->any(), (new Matcher())->annotatedWith(FakeAllPublicMethods::class), [$onion1]);
+        $this->bind->bind(FakeAnnotateClassAllPublicMethods::class, [$pointcut1]);
+        $actual = $this->bind->getBindings();
+        $expect = [
+            'getDouble' => [$onion1],
+            'getSome' => [$onion1],
         ];
         $this->assertSame($expect, $actual);
     }

--- a/tests/Fake/Annotation/FakeAllPublicMethods.php
+++ b/tests/Fake/Annotation/FakeAllPublicMethods.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Ray\Aop\Annotation;
+
+use Attribute;
+
+/**
+ * @Annotation
+ * @Target("ALL")
+ */
+#[Attribute(Attribute::TARGET_ALL)]
+class FakeAllPublicMethods extends AllPublicMethods
+{
+}

--- a/tests/Fake/FakeAnnotateClassAllPublicMethods.php
+++ b/tests/Fake/FakeAnnotateClassAllPublicMethods.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Aop;
+
+
+use Ray\Aop\Annotation\FakeAllPublicMethods;
+
+/**
+ * @FakeResource
+ * @FakeAllPublicMethods
+ */
+#[FakeAllPublicMethods]
+class FakeAnnotateClassAllPublicMethods
+{
+    public int $a = 0;
+
+    public function getDouble($a)
+    {
+        return $a * 2;
+    }
+
+    public function getSome($a): float|int
+    {
+        return $a + 2;
+    }
+}


### PR DESCRIPTION
Added:
`AllPublicMethods` attribute when used as class attribute it takes all public methods to intercept except `__constructor`