### PR TITLE
Create attribute_reader.php

### DIFF
--- a/attribute_reader.php
+++ b/attribute_reader.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+use Koriym\Attributes\AttributeReader;
+use Ray\ServiceLocator\ServiceLocator;
+
+ServiceLocator::setReader(new AttributeReader());


### PR DESCRIPTION
Adding this script in a project without Doctrine annotations (in a project with only PHP8 attributes) as follows will speed up development time by ignoring Doctrine annotations.

Doctrineアノテーションが無いプロジェクトで（PHP8 アトリビュートのみのプロジェクトで）このスクリプトを以下のように加えると、Doctrineアノテーションを無視して開発時に高速になります。

```json
  "autoload": {
    "files": [
      "vendor/ray/aop/attribute_reader.php"
    ]
```