### PR TITLE
Bump php parser to ^4.13.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.2 || ^8.0",
         "doctrine/annotations": "^1.12",
         "koriym/attributes": "^1.0.3",
-        "nikic/php-parser": "^v4.12"
+        "nikic/php-parser": "^4.13.2"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.4.1",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,9 @@
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-        bootstrap="tests/bootstrap.php">
+        bootstrap="tests/bootstrap.php"
+        convertDeprecationsToExceptions="true"
+>
   <testsuites>
     <testsuite name="Ray.Aop Test Suite">
       <directory>tests</directory>


### PR DESCRIPTION
以下のように8.2 の lowest dependency のテストにおいて php-parser の deprecate エラーが出ていたので修正されたバージョンの 4.13.2 を利用するように変更しました。

https://github.com/bearsunday/BEAR.Package/actions/runs/3856759902/jobs/6573359007

https://github.com/nikic/PHP-Parser/releases/tag/v4.13.2