### PR TITLE
tmpDirが存在するときのNOTICEを抑制する対応を実施

### DIFF
--- a/sl-src/Cache.php
+++ b/sl-src/Cache.php
@@ -6,9 +6,11 @@ namespace Ray\ServiceLocator;
 
 use Ray\ServiceLocator\Exception\DirectoryNotWritableException;
 
+use function chmod;
 use function file_exists;
 use function file_put_contents;
 use function hash;
+use function is_dir;
 use function is_writable;
 use function mkdir;
 use function pathinfo;
@@ -63,8 +65,13 @@ final class Cache
         $dir = $this->tmpDir
             . DIRECTORY_SEPARATOR
             . substr($hash, 0, 2);
-        if (! is_writable($dir)) {
+
+        if (! is_dir($dir)) {
             mkdir($dir, 0777, true);
+        }
+
+        if (! is_writable($dir)) {
+            chmod($dir, 0777);
         }
 
         return $dir


### PR DESCRIPTION
## 再現方法

PHPアプリケーションをビルドする際に
Dockerfileなどで事前にtmpDirを作成していると
ヘルスチェックなどの初回アクセスでコンパイラが動いたときに下記のエラーログが発生します。

## エラーログ

```
NOTICE: PHP message: PHP Warning:  mkdir(): File exists in ~/root/vendor/ray/aop/sl-src/Cache.php on line 67
```

## 対応内容

is_dirでtmpDirの存在確認を行い、なければmkdirで作成するようにしました。
is_writableで、falseのときにchmodするように修正しました。

