### PR TITLE
Fixed to not make mixed nullable

### DIFF
--- a/src/TypeString.php
+++ b/src/TypeString.php
@@ -39,7 +39,7 @@ final class TypeString
         if ($type instanceof ReflectionNamedType) {
             $typeStr = self::getFqnType($type);
             // Check for Nullable in single types
-            if ($type->allowsNull() && $type->getName() !== 'null') {
+            if ($typeStr !== 'mixed' && $type->allowsNull() && $type->getName() !== 'null') {
                 $typeStr = $this->nullableStr . $typeStr;
             }
 

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -342,4 +342,12 @@ class CompilerTest extends TestCase
         $this->assertInstanceOf(FakeAnonymousClass::class, $mock);
         $this->assertInstanceOf(WeavedInterface::class, $mock);
     }
+
+    /** @requires PHP 8.0 */
+    public function testMethodWithMixedArgument(): void
+    {
+        $mock = $this->compiler->newInstance(FakeMixedParamClass::class, [], $this->bind);
+        $this->assertInstanceOf(FakeMixedParamClass::class, $mock);
+        $this->assertInstanceOf(WeavedInterface::class, $mock);
+    }
 }

--- a/tests/Fake/FakeMixedParamClass.php
+++ b/tests/Fake/FakeMixedParamClass.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Aop;
+
+class FakeMixedParamClass
+{
+    public function returnSame(mixed $param): void
+    {
+    }
+}


### PR DESCRIPTION
Closes #210 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved type checking by ensuring nullable types are not marked as 'mixed'.

- **Tests**
	- Added a new test for methods with mixed type arguments in PHP 8.0.

- **New Features**
	- Introduced a new class that handles methods with mixed type parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->