### PR TITLE
Refactor AopPostfixClassName to include classDir

### DIFF
--- a/src/AopPostfixClassName.php
+++ b/src/AopPostfixClassName.php
@@ -18,10 +18,10 @@ final class AopPostfixClassName
     public $postFix;
 
     /** @param class-string $class */
-    public function __construct(string $class, string $bindings)
+    public function __construct(string $class, string $bindings, string $classDir)
     {
         $fileTime = (string) filemtime((string) (new ReflectionClass($class))->getFileName());
-        $this->postFix = '_' . crc32($fileTime . $bindings);
+        $this->postFix = '_' . crc32($fileTime . $bindings . $classDir);
         $this->fqn = $class . $this->postFix;
     }
 }

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -65,7 +65,7 @@ final class Compiler implements CompilerInterface
             return $class;
         }
 
-        $className = new AopPostfixClassName($class, (string) $bind);
+        $className = new AopPostfixClassName($class, (string) $bind, $this->classDir);
         if (class_exists($className->fqn, false)) {
             return $className->fqn;
         }

--- a/src/Weaver.php
+++ b/src/Weaver.php
@@ -62,7 +62,7 @@ final class Weaver
      */
     public function weave(string $class): string
     {
-        $aopClass = new AopPostfixClassName($class, $this->bindName);
+        $aopClass = new AopPostfixClassName($class, $this->bindName, $this->classDir);
         if (class_exists($aopClass->fqn, false)) {
             return $aopClass->fqn;
         }


### PR DESCRIPTION
Updated the AopPostfixClassName constructor to accept an additional classDir parameter, influencing the postfix generation process. Corresponding changes were made in Compiler and Weaver to pass this new parameter correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of class directory context in the `AopPostfixClassName`, improving its functionality.
	- Updated methods in the `Compiler` and `Weaver` classes to utilize the new class directory parameter, allowing for more context during operations.

- **Bug Fixes**
	- Improved the reliability of `postFix` generation by incorporating the class directory into its calculation.

- **Documentation**
	- Updated method signatures to reflect the addition of the class directory parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->