### PR TITLE
Enable PHP 8.4 compat

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -9,4 +9,4 @@ jobs:
   cs:
     uses: ray-di/.github/.github/workflows/coding-standards.yml@v1
     with:
-      php_version: 8.2
+      php_version: 8.3

--- a/.github/workflows/continuous-integration-pecl.yml
+++ b/.github/workflows/continuous-integration-pecl.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Upload Valgrind log file
         if: steps.build_extension.outcome == 'failure' || steps.run_pecl_demo.outcome == 'failure'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: valgrind-log
           path: valgrind-out.txt

--- a/.github/workflows/continuous-integration-pecl.yml
+++ b/.github/workflows/continuous-integration-pecl.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,6 +9,6 @@ jobs:
   ci:
     uses: ray-di/.github/.github/workflows/continuous-integration.yml@v1
     with:
-      old_stable: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2"]'
-      current_stable: 8.3
+      old_stable: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]'
+      current_stable: 8.4
       script: demo/run.php

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,6 +9,6 @@ jobs:
   sa:
     uses: ray-di/.github/.github/workflows/static-analysis.yml@v1
     with:
-      php_version: 8.2
+      php_version: 8.3
       has_crc_config: true
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated PHP version to 8.3 in various GitHub Actions workflows, enhancing compatibility and features for coding standards, static analysis, and continuous integration processes.

- **Chores**
	- Upgraded action versions in the continuous integration workflow to improve performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->