### PR TITLE
Binding multiple interceptors with multiple bindings in PECL AOP

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ $aspect->bind(
 
 $billing = $aspect->newInstance(RealBillingService::class);
 try {
-    echo $billing->chargeOrder();
+    echo $billing->chargeOrder(); // Interceptors applied
 } catch (\RuntimeException $e) {
     echo $e->getMessage() . "\n";
     exit(1);
@@ -103,7 +103,11 @@ $aspect->bind(
     (new Matcher())->annotatedWith(NotOnWeekends::class),
     [new WeekendBlocker()]
 );
-$aspect->weave(__DIR__ . '/src'); // Weave the aspects to all classes in the directory that match the matcher.
+// Weave aspects into all matching classes in the source directory
+$aspect->weave('/path/to/src');
+
+// Or weave into specific target directory
+$aspect->weave('/path/to/target');
 
 $billing = new RealBillingService();
 echo $billing->chargeOrder(); // Interceptors applied

--- a/src/AspectPecl.php
+++ b/src/AspectPecl.php
@@ -27,7 +27,7 @@ final class AspectPecl
 {
     public function __construct()
     {
-        if (!extension_loaded('rayaop')) {
+        if (! extension_loaded('rayaop')) {
             throw new RuntimeException('Ray.Aop extension is not loaded. Cannot use weave() method.'); // @codeCoverageIgnore
         }
     }
@@ -48,12 +48,12 @@ final class AspectPecl
                 continue;
             }
 
-            $this->apply($boundInterceptors);
+            $this->interceptMethods($boundInterceptors);
         }
     }
 
     /**
-     * Process class for interception
+     * Get interceptors bound to class methods based on matchers
      *
      * @param class-string      $className
      * @param MatcherConfigList $matchers
@@ -67,14 +67,14 @@ final class AspectPecl
 
         $bound = [];
         foreach ($matchers as $matcher) {
-            if (!$matcher['classMatcher']->matchesClass($reflection, $matcher['classMatcher']->getArguments())) {
+            if (! $matcher['classMatcher']->matchesClass($reflection, $matcher['classMatcher']->getArguments())) {
                 continue;
             }
 
             /** @var ReflectionMethod[] $methods */
             $methods = $reflection->getMethods(ReflectionMethod::IS_PUBLIC);
             foreach ($methods as $method) {
-                if (!$matcher['methodMatcher']->matchesMethod($method, $matcher['methodMatcher']->getArguments())) {
+                if (! $matcher['methodMatcher']->matchesMethod($method, $matcher['methodMatcher']->getArguments())) {
                     continue;
                 }
 
@@ -92,11 +92,11 @@ final class AspectPecl
     }
 
     /**
-     * Apply interceptors to bound methods
+     * Intercept methods with bounded interceptors using PECL extension
      *
      * @param ClassBoundInterceptors $boundInterceptors
      */
-    private function apply(array $boundInterceptors): void
+    private function interceptMethods(array $boundInterceptors): void
     {
         $dispatcher = new PeclDispatcher($boundInterceptors);
         assert(function_exists('\method_intercept')); // PECL Ray.Aop extension

--- a/src/AspectPecl.php
+++ b/src/AspectPecl.php
@@ -43,6 +43,10 @@ final class AspectPecl
     {
         foreach (new ClassList($classDir) as $className) {
             $boundInterceptors = $this->getBoundInterceptors($className, $mathcers);
+            if ($boundInterceptors === []) {
+                continue;
+            }
+
             $this->apply($boundInterceptors);
         }
     }

--- a/src/AspectPecl.php
+++ b/src/AspectPecl.php
@@ -9,6 +9,7 @@ use ReflectionMethod;
 use RuntimeException;
 
 use function array_keys;
+use function array_merge;
 use function assert;
 use function class_exists;
 use function extension_loaded;
@@ -77,7 +78,13 @@ final class AspectPecl
                     continue;
                 }
 
-                $bound[$className][$method->getName()] = $matcher['interceptors'];
+                $methodName = $method->getName();
+                if (isset($bound[$className][$methodName])) {
+                    $bound[$className][$methodName] = array_merge($bound[$className][$methodName], $matcher['interceptors']);
+                    continue;
+                }
+
+                $bound[$className][$methodName] = $matcher['interceptors'];
             }
         }
 

--- a/src/AspectPecl.php
+++ b/src/AspectPecl.php
@@ -27,7 +27,7 @@ final class AspectPecl
 {
     public function __construct()
     {
-        if (! extension_loaded('rayaop')) {
+        if (!extension_loaded('rayaop')) {
             throw new RuntimeException('Ray.Aop extension is not loaded. Cannot use weave() method.'); // @codeCoverageIgnore
         }
     }
@@ -36,14 +36,14 @@ final class AspectPecl
      * Weave aspects into classes in the specified directory
      *
      * @param non-empty-string  $classDir Target class directory
-     * @param MatcherConfigList $mathcers List of matchers and interceptors
+     * @param MatcherConfigList $matchers List of matchers and interceptors
      *
      * @throws RuntimeException When Ray.Aop extension is not loaded.
      */
-    public function weave(string $classDir, array $mathcers): void
+    public function weave(string $classDir, array $matchers): void
     {
         foreach (new ClassList($classDir) as $className) {
-            $boundInterceptors = $this->getBoundInterceptors($className, $mathcers);
+            $boundInterceptors = $this->getBoundInterceptors($className, $matchers);
             if ($boundInterceptors === []) {
                 continue;
             }
@@ -67,14 +67,14 @@ final class AspectPecl
 
         $bound = [];
         foreach ($matchers as $matcher) {
-            if (! $matcher['classMatcher']->matchesClass($reflection, $matcher['classMatcher']->getArguments())) {
+            if (!$matcher['classMatcher']->matchesClass($reflection, $matcher['classMatcher']->getArguments())) {
                 continue;
             }
 
             /** @var ReflectionMethod[] $methods */
             $methods = $reflection->getMethods(ReflectionMethod::IS_PUBLIC);
             foreach ($methods as $method) {
-                if (! $matcher['methodMatcher']->matchesMethod($method, $matcher['methodMatcher']->getArguments())) {
+                if (!$matcher['methodMatcher']->matchesMethod($method, $matcher['methodMatcher']->getArguments())) {
                     continue;
                 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced clarity and context in the `README.md` for using the Ray.Aop package, including improved examples and instructions for interceptors and aspect configuration.

- **Refactor**
	- Improved naming consistency in the `AspectPecl` class by renaming parameters and methods for better clarity.
	- Enhanced control flow in the `weave` method to skip processing when no interceptors are bound, improving efficiency.
	- Updated handling of bound interceptors to allow accumulation rather than overwriting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->