### PR TITLE
Add stability section to README files

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -226,4 +226,10 @@ SevericeLocator::setReader(new AttributeReader);`
 
 DIとAOPを統合したDIフレームワーク[Ray.Di](https://github.com/ray-di/Ray.Di)もご覧ください。
 
+## 安定性
+
+Ray.Aopはセマンティックバージョニングに従い、後方互換性を保証します。2015年のバージョン2.0以降、PHPの進化に合わせて機能を拡張しながら互換性を維持してきました。今後もこの安定性を維持していきます。
+
+---
+
 * この文書の大部分は [Guice/AOP](https://github.com/google/guice/wiki/AOP) から借用しています。

--- a/README.md
+++ b/README.md
@@ -248,6 +248,10 @@ SevericeLocator::setReader(new AttributeReader);`
 
 * See also the DI framework [Ray.Di](https://github.com/ray-di/Ray.Di) which integrates DI and AOP.
 
+## Stability
+
+Ray.Aop follows semantic versioning and ensures backward compatibility. Released in 2015, version 2.0 and its successors have maintained compatibility while evolving with PHP, and we remain committed to this stability.
+
 ---
 
 * Note: This documentation of the part is taken from [Guice/AOP](https://github.com/google/guice/wiki/AOP).


### PR DESCRIPTION
Added a new section detailing the stability of Ray.Aop in both README.ja.md and README.md. The section explains the project's adherence to semantic versioning and its commitment to maintaining backward compatibility since version 2.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a new "Stability" section to both `README.md` and `README.ja.md`, highlighting adherence to semantic versioning and commitment to backward compatibility since 2015.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->