### PR TITLE
Fix return type of getConstructor

### DIFF
--- a/src/ReflectionClass.php
+++ b/src/ReflectionClass.php
@@ -68,7 +68,7 @@ class ReflectionClass extends \ReflectionClass implements Reader
      * @psalm-suppress MethodSignatureMismatch
      * @psalm-external-mutation-free
      */
-    public function getConstructor(): ?ReflectionMethod
+    public function getConstructor(): ?\ReflectionMethod
     {
         $parent = parent::getConstructor();
         if ($parent === null) {


### PR DESCRIPTION
# Summary

Fatal error occurs with the optimized autoloader.

```
PHP Fatal error: Could not check compatibility between Ray\Aop\ReflectionClass::getConstructor(): ?Ray\Aop\ReflectionMethod and ReflectionClass::getConstructor(): ?ReflectionMethod, because class Ray\Aop\ReflectionMethod is not available in ...
```

# How to Reproduce

Place the following script in the root of this project and execute it.

```
<?php

require __DIR__ . '/src/Reader.php';
require __DIR__ . '/src/ReflectionClass.php';
```

## Summary by Sourcery

Bug Fixes:
- Fixed a fatal error that occurred when using the optimized autoloader.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Refined internal type declarations for enhanced clarity and consistency. This update does not change application behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->