### PR TITLE
Add support for readonly class in PHP 8.2

### DIFF
--- a/src-php8/Php82InterceptTrait.php
+++ b/src-php8/Php82InterceptTrait.php
@@ -9,17 +9,15 @@ use Ray\Aop\ReflectiveMethodInvocation as Invocation;
 use function call_user_func_array;
 
 /**
- * WARNING: All properties in this trait must be readonly to allow its use in a readonly class.
+ * @psalm-import-type MethodBindings from Types
+ * @psalm-import-type Arguments from Types
  */
 trait Php82InterceptTrait
 {
-    /**
-     * @var InterceptTraitState
-     */
     private readonly InterceptTraitState $_state;
 
     /**
-     * @param array<string, array<MethodInterceptor|string>> $bindings
+     * @param MethodBindings $bindings
      *
      * @see WeavedInterface::_initState()
      */
@@ -29,7 +27,7 @@ trait Php82InterceptTrait
     }
 
     /**
-     * @param array<string, mixed> $args
+     * @param Arguments $args
      *
      * @return mixed
      *

--- a/src-php8/Php82InterceptTrait.php
+++ b/src-php8/Php82InterceptTrait.php
@@ -25,7 +25,7 @@ trait Php82InterceptTrait
      */
     public function _initState(array $bindings): void
     {
-        $this->_state = new InterceptTraitState($bindings, true);
+        $this->_state = new InterceptTraitState($bindings);
     }
 
     /**

--- a/src-php8/Php82InterceptTrait.php
+++ b/src-php8/Php82InterceptTrait.php
@@ -15,9 +15,8 @@ trait Php82InterceptTrait
 {
     /**
      * @var InterceptTraitState
-     * @internal Public for CompilerTest
      */
-    public readonly InterceptTraitState $_state;
+    private readonly InterceptTraitState $_state;
 
     /**
      * @param array<string, array<MethodInterceptor|string>> $bindings

--- a/src-php8/Php82InterceptTrait.php
+++ b/src-php8/Php82InterceptTrait.php
@@ -17,7 +17,7 @@ trait Php82InterceptTrait
      * @var InterceptTraitState
      * @internal Public for CompilerTest
      */
-    public readonly InterceptTraitState $state;
+    public readonly InterceptTraitState $_state;
 
     /**
      * @param array<string, array<MethodInterceptor|string>> $bindings
@@ -26,7 +26,7 @@ trait Php82InterceptTrait
      */
     public function _initState(array $bindings): void
     {
-        $this->state = new InterceptTraitState($bindings, true);
+        $this->_state = new InterceptTraitState($bindings, true);
     }
 
     /**
@@ -38,15 +38,15 @@ trait Php82InterceptTrait
      */
     private function _intercept(string $func, array $args) // phpcs:ignore
     {
-        if (! $this->state->isAspect) {
-            $this->state->isAspect = true;
+        if (! $this->_state->isAspect) {
+            $this->_state->isAspect = true;
 
             return call_user_func_array([parent::class, $func], $args);
         }
 
-        $this->state->isAspect = false;
-        $result = (new Invocation($this, $func, $args, $this->state->bindings[$func]))->proceed();
-        $this->state->isAspect = true;
+        $this->_state->isAspect = false;
+        $result = (new Invocation($this, $func, $args, $this->_state->bindings[$func]))->proceed();
+        $this->_state->isAspect = true;
 
         return $result;
     }

--- a/src-php8/Php82InterceptTrait.php
+++ b/src-php8/Php82InterceptTrait.php
@@ -22,9 +22,9 @@ trait Php82InterceptTrait
     /**
      * @param array<string, array<MethodInterceptor|string>> $bindings
      *
-     * @see WeavedInterface::initState()
+     * @see WeavedInterface::_initState()
      */
-    public function initState(array $bindings): void
+    public function _initState(array $bindings): void
     {
         $this->state = new InterceptTraitState($bindings, true);
     }

--- a/src-php8/Php82InterceptTrait.php
+++ b/src-php8/Php82InterceptTrait.php
@@ -8,14 +8,16 @@ use Ray\Aop\ReflectiveMethodInvocation as Invocation;
 
 use function call_user_func_array;
 
-trait InterceptTrait
+/**
+ * WARNING: All properties in this trait must be readonly to allow its use in a readonly class.
+ */
+trait Php82InterceptTrait
 {
     /**
      * @var InterceptTraitState
-     * @readonly
      * @internal Public for CompilerTest
      */
-    public $state;
+    public readonly InterceptTraitState $state;
 
     /**
      * @param array<string, array<MethodInterceptor|string>> $bindings

--- a/src/AopCode.php
+++ b/src/AopCode.php
@@ -19,6 +19,7 @@ use function preg_replace_callback;
 use function sprintf;
 use function token_get_all;
 
+use const PHP_VERSION_ID;
 use const T_CLASS;
 use const T_EXTENDS;
 use const T_STRING;
@@ -202,7 +203,9 @@ final class AopCode
     /** @psalm-external-mutation-free */
     private function addIntercepterTrait(): void
     {
-        $this->add(sprintf("{\n    use \%s;\n}\n", InterceptTrait::class));
+        PHP_VERSION_ID >= 80200
+            ? $this->add(sprintf("{\n    use \%s;\n}\n", Php82InterceptTrait::class))
+            : $this->add(sprintf("{\n    use \%s;\n}\n", InterceptTrait::class));
     }
 
     /** @psalm-external-mutation-free */

--- a/src/BindInterface.php
+++ b/src/BindInterface.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Ray\Aop;
 
-/** @psalm-import-type MethodName from Types */
+/**
+ * @psalm-import-type MethodName from Types
+ * @psalm-import-type MethodBindings from Types
+ */
 interface BindInterface
 {
     /**
@@ -28,7 +31,7 @@ interface BindInterface
      *
      * [$methodNameA => [$interceptorA, ...][]
      *
-     * @return array<string, array<MethodInterceptor|string>>
+     * @return MethodBindings
      */
     public function getBindings();
 

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -65,7 +65,7 @@ final class Compiler implements CompilerInterface
         assert(class_exists($compiledClass));
         $instance = (new ReflectionClass($compiledClass))->newInstanceArgs($args);
         if ($instance instanceof WeavedInterface) {
-            $instance->initState($bind->getBindings());
+            $instance->_initState($bind->getBindings());
         }
 
         assert($instance instanceof $class);

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -64,9 +64,8 @@ final class Compiler implements CompilerInterface
         $compiledClass = $this->compile($class, $bind);
         assert(class_exists($compiledClass));
         $instance = (new ReflectionClass($compiledClass))->newInstanceArgs($args);
-        assert($instance instanceof $class);
-        if (isset($instance->bindings)) {
-            $instance->bindings = $bind->getBindings();
+        if ($instance instanceof WeavedInterface) {
+            $instance->initState($bind->getBindings());
         }
 
         assert($instance instanceof $class);

--- a/src/InterceptTrait.php
+++ b/src/InterceptTrait.php
@@ -21,9 +21,10 @@ trait InterceptTrait
     /**
      * @param MethodBindings $bindings
      *
-     * @see WeavedInterface::initState()
+     * @see WeavedInterface::_initState()
+     * @SuppressWarnings(PHPMD.CamelCaseMethodName)
      */
-    public function initState(array $bindings): void
+    public function _initState(array $bindings): void // phpcs:ignore
     {
         $this->state = new InterceptTraitState($bindings, true);
     }

--- a/src/InterceptTrait.php
+++ b/src/InterceptTrait.php
@@ -14,6 +14,7 @@ trait InterceptTrait
     /**
      * @var InterceptTraitState
      * @readonly
+     * @psalm-suppress MissingConstructor
      */
     private $_state;
 
@@ -25,7 +26,7 @@ trait InterceptTrait
      */
     public function _initState(array $bindings): void // phpcs:ignore
     {
-        $this->_state = new InterceptTraitState($bindings, true);
+        $this->_state = new InterceptTraitState($bindings);
     }
 
     /**

--- a/src/InterceptTrait.php
+++ b/src/InterceptTrait.php
@@ -16,7 +16,7 @@ trait InterceptTrait
      * @readonly
      * @internal Public for CompilerTest
      */
-    public $state;
+    public $_state;
 
     /**
      * @param MethodBindings $bindings
@@ -26,7 +26,7 @@ trait InterceptTrait
      */
     public function _initState(array $bindings): void // phpcs:ignore
     {
-        $this->state = new InterceptTraitState($bindings, true);
+        $this->_state = new InterceptTraitState($bindings, true);
     }
 
     /**
@@ -38,15 +38,15 @@ trait InterceptTrait
      */
     private function _intercept(string $func, array $args) // phpcs:ignore
     {
-        if (! $this->state->isAspect) {
-            $this->state->isAspect = true;
+        if (! $this->_state->isAspect) {
+            $this->_state->isAspect = true;
 
             return call_user_func_array([parent::class, $func], $args);
         }
 
-        $this->state->isAspect = false;
-        $result = (new Invocation($this, $func, $args, $this->state->bindings[$func]))->proceed();
-        $this->state->isAspect = true;
+        $this->_state->isAspect = false;
+        $result = (new Invocation($this, $func, $args, $this->_state->bindings[$func]))->proceed();
+        $this->_state->isAspect = true;
 
         return $result;
     }

--- a/src/InterceptTrait.php
+++ b/src/InterceptTrait.php
@@ -14,9 +14,8 @@ trait InterceptTrait
     /**
      * @var InterceptTraitState
      * @readonly
-     * @internal Public for CompilerTest
      */
-    public $_state;
+    private $_state;
 
     /**
      * @param MethodBindings $bindings

--- a/src/InterceptTrait.php
+++ b/src/InterceptTrait.php
@@ -8,6 +8,7 @@ use Ray\Aop\ReflectiveMethodInvocation as Invocation;
 
 use function call_user_func_array;
 
+/** @psalm-import-type MethodBindings from Types */
 trait InterceptTrait
 {
     /**
@@ -18,7 +19,7 @@ trait InterceptTrait
     public $state;
 
     /**
-     * @param array<string, array<MethodInterceptor|string>> $bindings
+     * @param MethodBindings $bindings
      *
      * @see WeavedInterface::initState()
      */

--- a/src/InterceptTraitState.php
+++ b/src/InterceptTraitState.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Aop;
+
+final class InterceptTraitState
+{
+    /**
+     * @var array<string, array<class-string<MethodInterceptor>>>
+     * @readonly
+     */
+    public $bindings;
+
+    /** @var bool */
+    public $isAspect;
+
+    /**
+     * @param array<string, array<class-string<MethodInterceptor>>> $bindings
+     * @param bool                                                  $isAspect
+     */
+    public function __construct($bindings, $isAspect)
+    {
+        $this->bindings = $bindings;
+        $this->isAspect = $isAspect;
+    }
+}

--- a/src/InterceptTraitState.php
+++ b/src/InterceptTraitState.php
@@ -4,24 +4,21 @@ declare(strict_types=1);
 
 namespace Ray\Aop;
 
+/** @psalm-import-type MethodBindings from Types */
 final class InterceptTraitState
 {
     /**
-     * @var array<string, array<class-string<MethodInterceptor>>>
+     * @var MethodBindings
      * @readonly
      */
     public $bindings;
 
     /** @var bool */
-    public $isAspect;
+    public $isAspect = true;
 
-    /**
-     * @param array<string, array<class-string<MethodInterceptor>>> $bindings
-     * @param bool                                                  $isAspect
-     */
-    public function __construct($bindings, $isAspect)
+    /** @param MethodBindings $bindings */
+    public function __construct(array $bindings)
     {
         $this->bindings = $bindings;
-        $this->isAspect = $isAspect;
     }
 }

--- a/src/WeavedInterface.php
+++ b/src/WeavedInterface.php
@@ -7,6 +7,10 @@ namespace Ray\Aop;
 /** @psalm-import-type MethodBindings from Types */
 interface WeavedInterface
 {
-    /** @param MethodBindings $bindings */
-    public function initState(array $bindings): void;
+    /**
+     * @param MethodBindings $bindings
+     *
+     * @SuppressWarnings(PHPMD.CamelCaseMethodName)
+     */
+    public function _initState(array $bindings): void; // phpcs:ignore
 }

--- a/src/WeavedInterface.php
+++ b/src/WeavedInterface.php
@@ -6,4 +6,6 @@ namespace Ray\Aop;
 
 interface WeavedInterface
 {
+    /** @param array<string, array<MethodInterceptor|string>> $bindings */
+    public function initState(array $bindings): void;
 }

--- a/src/WeavedInterface.php
+++ b/src/WeavedInterface.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace Ray\Aop;
 
+/** @psalm-import-type MethodBindings from Types */
 interface WeavedInterface
 {
-    /** @param array<string, array<MethodInterceptor|string>> $bindings */
+    /** @param MethodBindings $bindings */
     public function initState(array $bindings): void;
 }

--- a/src/Weaver.php
+++ b/src/Weaver.php
@@ -57,12 +57,12 @@ final class Weaver
     {
         $aopClass = $this->weave($class);
         $instance = (new ReflectionClass($aopClass))->newInstanceArgs($args);
-        if (! isset($instance->bindings)) {
+        if (! $instance instanceof WeavedInterface) {
             /** @var T $instance  */
             return $instance;
         }
 
-        $instance->bindings = $this->bind->getBindings();
+        $instance->initState($this->bind->getBindings());
         assert($instance instanceof $class);
 
         return $instance;

--- a/src/Weaver.php
+++ b/src/Weaver.php
@@ -62,7 +62,7 @@ final class Weaver
             return $instance;
         }
 
-        $instance->initState($this->bind->getBindings());
+        $instance->_initState($this->bind->getBindings());
         assert($instance instanceof $class);
 
         return $instance;

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -78,8 +78,8 @@ class CompilerTest extends TestCase
     /** @depends testNewInstance */
     public function testBuildClassWeaved(FakeMock $weaved): void
     {
-        assert(property_exists($weaved, 'state'));
-        $weaved->state->bindings = $this->bind->getBindings();
+        assert(property_exists($weaved, '_state'));
+        $weaved->_state->bindings = $this->bind->getBindings();
         $result = $weaved->returnSame(1);
         $this->assertSame(2, $result);
     }
@@ -117,8 +117,7 @@ class CompilerTest extends TestCase
     {
         $mock = $this->compiler->newInstance(FakeMockGrandChild::class, [], $this->bind);
         assert($mock instanceof FakeMockGrandChild);
-        assert(property_exists($mock, 'state'));
-        $mock->state->bindings = $this->bind->getBindings();
+        assert(property_exists($mock, '_state'));
         $result = $mock->returnSame(1);
         $this->assertSame(2, $result);
     }
@@ -128,8 +127,8 @@ class CompilerTest extends TestCase
         $bind = (new Bind())->bindInterceptors('passIterator', [new NullInterceptor()]);
         $mock = $this->compiler->newInstance(FakeTypedMockGrandChild::class, [], $bind);
         assert($mock instanceof FakeTypedMockGrandChild);
-        assert(property_exists($mock, 'state'));
-        $mock->state->bindings = $bind->getBindings();
+        assert(property_exists($mock, '_state'));
+        $mock->_state->bindings = $bind->getBindings();
         $result = $mock->passIterator(new ArrayIterator());
         $this->assertInstanceOf(ArrayIterator::class, $result);
     }
@@ -138,8 +137,8 @@ class CompilerTest extends TestCase
     {
         $mock = $this->compiler->newInstance(FakeMockChildChild::class, [], $this->bind);
         assert($mock instanceof FakeMockChild);
-        assert(property_exists($mock, 'state'));
-        $mock->state->bindings = $this->bind->getBindings();
+        assert(property_exists($mock, '_state'));
+        $mock->_state->bindings = $this->bind->getBindings();
         $result = $mock->returnSame(1);
         $this->assertSame(2, $result);
     }

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -78,8 +78,8 @@ class CompilerTest extends TestCase
     /** @depends testNewInstance */
     public function testBuildClassWeaved(FakeMock $weaved): void
     {
-        assert(isset($weaved->bindings));
-        $weaved->bindings = $this->bind->getBindings();
+        assert(property_exists($weaved, 'state'));
+        $weaved->state->bindings = $this->bind->getBindings();
         $result = $weaved->returnSame(1);
         $this->assertSame(2, $result);
     }
@@ -117,8 +117,8 @@ class CompilerTest extends TestCase
     {
         $mock = $this->compiler->newInstance(FakeMockGrandChild::class, [], $this->bind);
         assert($mock instanceof FakeMockGrandChild);
-        assert(property_exists($mock, 'bindings'));
-        $mock->bindings = $this->bind->getBindings();
+        assert(property_exists($mock, 'state'));
+        $mock->state->bindings = $this->bind->getBindings();
         $result = $mock->returnSame(1);
         $this->assertSame(2, $result);
     }
@@ -128,8 +128,8 @@ class CompilerTest extends TestCase
         $bind = (new Bind())->bindInterceptors('passIterator', [new NullInterceptor()]);
         $mock = $this->compiler->newInstance(FakeTypedMockGrandChild::class, [], $bind);
         assert($mock instanceof FakeTypedMockGrandChild);
-        assert(property_exists($mock, 'bindings'));
-        $mock->bindings = $bind->getBindings();
+        assert(property_exists($mock, 'state'));
+        $mock->state->bindings = $bind->getBindings();
         $result = $mock->passIterator(new ArrayIterator());
         $this->assertInstanceOf(ArrayIterator::class, $result);
     }
@@ -138,8 +138,8 @@ class CompilerTest extends TestCase
     {
         $mock = $this->compiler->newInstance(FakeMockChildChild::class, [], $this->bind);
         assert($mock instanceof FakeMockChild);
-        assert(property_exists($mock, 'bindings'));
-        $mock->bindings = $this->bind->getBindings();
+        assert(property_exists($mock, 'state'));
+        $mock->state->bindings = $this->bind->getBindings();
         $result = $mock->returnSame(1);
         $this->assertSame(2, $result);
     }
@@ -348,6 +348,14 @@ class CompilerTest extends TestCase
     {
         $mock = $this->compiler->newInstance(FakeMixedParamClass::class, [], $this->bind);
         $this->assertInstanceOf(FakeMixedParamClass::class, $mock);
+        $this->assertInstanceOf(WeavedInterface::class, $mock);
+    }
+
+    /** @requires PHP 8.2 */
+    public function testNewInstanceWithPhp82ReadOnlyClass(): void
+    {
+        $mock = $this->compiler->newInstance(FakePhp82ReadOnlyClass::class, [], $this->bind);
+        $this->assertInstanceOf(FakePhp82ReadOnlyClass::class, $mock);
         $this->assertInstanceOf(WeavedInterface::class, $mock);
     }
 }

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -78,8 +78,6 @@ class CompilerTest extends TestCase
     /** @depends testNewInstance */
     public function testBuildClassWeaved(FakeMock $weaved): void
     {
-        assert(property_exists($weaved, '_state'));
-        $weaved->_state->bindings = $this->bind->getBindings();
         $result = $weaved->returnSame(1);
         $this->assertSame(2, $result);
     }
@@ -128,7 +126,6 @@ class CompilerTest extends TestCase
         $mock = $this->compiler->newInstance(FakeTypedMockGrandChild::class, [], $bind);
         assert($mock instanceof FakeTypedMockGrandChild);
         assert(property_exists($mock, '_state'));
-        $mock->_state->bindings = $bind->getBindings();
         $result = $mock->passIterator(new ArrayIterator());
         $this->assertInstanceOf(ArrayIterator::class, $result);
     }
@@ -138,7 +135,6 @@ class CompilerTest extends TestCase
         $mock = $this->compiler->newInstance(FakeMockChildChild::class, [], $this->bind);
         assert($mock instanceof FakeMockChild);
         assert(property_exists($mock, '_state'));
-        $mock->_state->bindings = $this->bind->getBindings();
         $result = $mock->returnSame(1);
         $this->assertSame(2, $result);
     }

--- a/tests/Fake/FakeMockChild.php
+++ b/tests/Fake/FakeMockChild.php
@@ -6,4 +6,5 @@ namespace Ray\Aop;
 
 class FakeMockChild extends FakeMock
 {
+    public $state;
 }

--- a/tests/Fake/FakePhp82ReadOnlyClass.php
+++ b/tests/Fake/FakePhp82ReadOnlyClass.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Aop;
+
+readonly class FakePhp82ReadOnlyClass {}

--- a/tests/Fake/FakeWeavedClass.php
+++ b/tests/Fake/FakeWeavedClass.php
@@ -6,4 +6,8 @@ namespace Ray\Aop;
 
 class FakeWeavedClass extends FakeClass implements WeavedInterface
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function initState(array $bindings): void {}
 }

--- a/tests/Fake/FakeWeavedClass.php
+++ b/tests/Fake/FakeWeavedClass.php
@@ -9,5 +9,5 @@ class FakeWeavedClass extends FakeClass implements WeavedInterface
     /**
      * {@inheritDoc}
      */
-    public function initState(array $bindings): void {}
+    public function _initState(array $bindings): void {}
 }

--- a/tests/tmp_unerase/Ray_Aop_FakeWeaverMock_523567342.php
+++ b/tests/tmp_unerase/Ray_Aop_FakeWeaverMock_523567342.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Aop;
+
+/** doc comment of FakeMock */
+class FakeWeaverMock_523567342 extends FakeWeaverMock implements \Ray\Aop\WeavedInterface 
+{
+    use \Ray\Aop\Php82InterceptTrait;
+    /**
+     * doc comment of returnSame
+     */
+      public function returnSame($a)
+    {
+        return $this->_intercept(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * doc comment of getSub
+     */
+      public function getSub($a, $b)
+    {
+        return $this->_intercept(__FUNCTION__, func_get_args());
+    }
+
+    public function returnValue(null|\Ray\Aop\FakeNum $num = NULL)
+    {
+        return $this->_intercept(__FUNCTION__, func_get_args());
+    }
+
+    public function getPrivateVal()
+    {
+        return $this->_intercept(__FUNCTION__, func_get_args());
+    }
+}


### PR DESCRIPTION
#235 のPRです。

## Summary by Sourcery

Add support for readonly classes in PHP 8.2.

New Features:
- Support readonly classes in PHP 8.2

Tests:
- Added a test for readonly class instantiation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced aspect-oriented capabilities that automatically select the optimal interception behavior based on the PHP version, fully supporting PHP 8.2’s readonly properties.
	- Improved state management for more consistent and flexible behavior across different environments.
	- Introduced a new readonly class to demonstrate PHP 8.2 compatibility.
	- Added a new method to the `WeavedInterface` for improved binding initialization.

- **Tests**
	- Added comprehensive tests to verify PHP 8.2 compatibility, including scenarios for readonly classes and enhanced interception functionality.
	- Updated tests to reflect changes in state management and bindings access.
	- Introduced new test cases to validate the instantiation of classes compatible with PHP 8.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->