### PR TITLE
Refactor codebase to use SetStateInterface

### DIFF
--- a/src/AopCode.php
+++ b/src/AopCode.php
@@ -56,7 +56,7 @@ final class AopCode
     public function generate(ReflectionClass $sourceClass, BindInterface $bind, string $postfix): string
     {
         $this->parseClass($sourceClass, $postfix);
-        $this->implementsInterface(WeavedInterface::class);
+        $this->implementsInterface(SetStateInterface::class);
         $this->addMethods($sourceClass, $bind);
 
         return $this->getCodeText();

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -64,7 +64,7 @@ final class Compiler implements CompilerInterface
         $compiledClass = $this->compile($class, $bind);
         assert(class_exists($compiledClass));
         $instance = (new ReflectionClass($compiledClass))->newInstanceArgs($args);
-        if ($instance instanceof WeavedInterface) {
+        if ($instance instanceof SetStateInterface) {
             $instance->_initState($bind->getBindings());
         }
 

--- a/src/InterceptTrait.php
+++ b/src/InterceptTrait.php
@@ -21,7 +21,8 @@ trait InterceptTrait
     /**
      * @param MethodBindings $bindings
      *
-     * @see WeavedInterface::_initState()
+     * {@inheritDoc}
+     *
      * @SuppressWarnings(PHPMD.CamelCaseMethodName)
      */
     public function _initState(array $bindings): void // phpcs:ignore

--- a/src/SetStateInterface.php
+++ b/src/SetStateInterface.php
@@ -7,7 +7,7 @@ namespace Ray\Aop;
 use Ray\Aop\MethodInterceptor as MethodBindings;
 
 /** @psalm-import-type MethodBindings from Types */
-interface SetStateInterface extends WeavedInterface
+interface SetStateInterface extends WeavedInterface // @phpstan-ignore-line
 {
     /**
      * @param MethodBindings $bindings

--- a/src/SetStateInterface.php
+++ b/src/SetStateInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Aop;
+
+use Ray\Aop\MethodInterceptor as MethodBindings;
+
+/** @psalm-import-type MethodBindings from Types */
+interface SetStateInterface extends WeavedInterface
+{
+    /**
+     * @param MethodBindings $bindings
+     *
+     * @SuppressWarnings(PHPMD.CamelCaseMethodName)
+     */
+    public function _initState(array $bindings): void; // phpcs:ignore
+}

--- a/src/WeavedInterface.php
+++ b/src/WeavedInterface.php
@@ -4,13 +4,6 @@ declare(strict_types=1);
 
 namespace Ray\Aop;
 
-/** @psalm-import-type MethodBindings from Types */
 interface WeavedInterface
 {
-    /**
-     * @param MethodBindings $bindings
-     *
-     * @SuppressWarnings(PHPMD.CamelCaseMethodName)
-     */
-    public function _initState(array $bindings): void; // phpcs:ignore
 }

--- a/src/Weaver.php
+++ b/src/Weaver.php
@@ -57,7 +57,7 @@ final class Weaver
     {
         $aopClass = $this->weave($class);
         $instance = (new ReflectionClass($aopClass))->newInstanceArgs($args);
-        if (! $instance instanceof WeavedInterface) {
+        if (! $instance instanceof SetStateInterface) {
             /** @var T $instance  */
             return $instance;
         }


### PR DESCRIPTION
This pull request updates the codebase to use the new SetStateInterface instead of WeavedInterface, including method checks, class generation, and documentation adjustments.

## Summary by Sourcery

Enhancements:
- Refactor codebase to use `SetStateInterface` instead of `WeavedInterface` for managing state in interceptors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new interface to support enhanced state management in dynamically generated classes.
  
- **Refactor**
  - Updated internal checks to use the new state management interface and streamlined instance initialization.
  - Removed legacy state initialization from the previous interface.
  
- **Documentation**
  - Refined documentation annotations to inherit standardized details for state initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->