### PR TITLE
Supports AOP targeting PHP 8.2 readonly classes

### DIFF
--- a/src-php8/ReadOnlyInterceptTrait.php
+++ b/src-php8/ReadOnlyInterceptTrait.php
@@ -19,9 +19,9 @@ trait ReadOnlyInterceptTrait
     /**
      * @param MethodBindings $bindings
      *
-     * @see WeavedInterface::_initState()
+     * @see WeavedInterface::_setBindings()
      */
-    public function _initState(array $bindings): void
+    public function _setBindings(array $bindings): void
     {
         $this->_state = new InterceptTraitState($bindings);
     }

--- a/src-php8/ReadOnlyInterceptTrait.php
+++ b/src-php8/ReadOnlyInterceptTrait.php
@@ -12,7 +12,7 @@ use function call_user_func_array;
  * @psalm-import-type MethodBindings from Types
  * @psalm-import-type Arguments from Types
  */
-trait Php82InterceptTrait
+trait ReadOnlyInterceptTrait
 {
     private readonly InterceptTraitState $_state;
 

--- a/src/AopCode.php
+++ b/src/AopCode.php
@@ -139,7 +139,8 @@ final class AopCode
 
             $isClassSignatureEnds = $inClass && $text === '{';
             if ($isClassSignatureEnds) {
-                $this->addIntercepterTrait();
+                $isReadOnly = PHP_VERSION_ID >= 80000 && $sourceClass->isReadOnly();
+                $isReadOnly ? $this->addReadOnlyIntercepterTrait() : $this->addIntercepterTrait();
 
                 return;
             }
@@ -203,9 +204,13 @@ final class AopCode
     /** @psalm-external-mutation-free */
     private function addIntercepterTrait(): void
     {
-        PHP_VERSION_ID >= 80200
-            ? $this->add(sprintf("{\n    use \%s;\n}\n", Php82InterceptTrait::class))
-            : $this->add(sprintf("{\n    use \%s;\n}\n", InterceptTrait::class));
+        $this->add(sprintf("{\n    use \%s;\n}\n", InterceptTrait::class));
+    }
+
+    /** @psalm-external-mutation-free */
+    private function addReadOnlyIntercepterTrait(): void
+    {
+        $this->add(sprintf("{\n    use \%s;\n}\n", Php82InterceptTrait::class));
     }
 
     /** @psalm-external-mutation-free */

--- a/src/AopCode.php
+++ b/src/AopCode.php
@@ -207,7 +207,7 @@ final class AopCode
     }
 
     /** @psalm-external-mutation-free */
-    private function addReadOnlyIntercepterTrait(): void
+    private function addReadOnlyInterceptorTrait(): void
     {
         $this->add(sprintf("{\n    use \%s;\n}\n", ReadOnlyInterceptTrait::class));
     }
@@ -228,7 +228,7 @@ final class AopCode
     public function resolveInterceptTrait(ReflectionClass $sourceClass): void
     {
         if (PHP_VERSION_ID >= 80200 && $sourceClass->isReadOnly()) {
-            $this->addReadOnlyIntercepterTrait();
+            $this->addReadOnlyInterceptorTrait();
 
             return;
         }

--- a/src/AopCode.php
+++ b/src/AopCode.php
@@ -139,8 +139,7 @@ final class AopCode
 
             $isClassSignatureEnds = $inClass && $text === '{';
             if ($isClassSignatureEnds) {
-                $isReadOnly = PHP_VERSION_ID >= 80000 && $sourceClass->isReadOnly();
-                $isReadOnly ? $this->addReadOnlyIntercepterTrait() : $this->addIntercepterTrait();
+                $this->resolveInterceptTrait($sourceClass);
 
                 return;
             }
@@ -202,7 +201,7 @@ final class AopCode
     }
 
     /** @psalm-external-mutation-free */
-    private function addIntercepterTrait(): void
+    private function addInterceporTrait(): void
     {
         $this->add(sprintf("{\n    use \%s;\n}\n", InterceptTrait::class));
     }
@@ -210,7 +209,7 @@ final class AopCode
     /** @psalm-external-mutation-free */
     private function addReadOnlyIntercepterTrait(): void
     {
-        $this->add(sprintf("{\n    use \%s;\n}\n", Php82InterceptTrait::class));
+        $this->add(sprintf("{\n    use \%s;\n}\n", ReadOnlyInterceptTrait::class));
     }
 
     /** @psalm-external-mutation-free */
@@ -223,5 +222,17 @@ final class AopCode
         }
 
         return $this->code;
+    }
+
+    /** @param ReflectionClass<object> $sourceClass */
+    public function resolveInterceptTrait(ReflectionClass $sourceClass): void
+    {
+        if (PHP_VERSION_ID >= 80200 && $sourceClass->isReadOnly()) {
+            $this->addReadOnlyIntercepterTrait();
+
+            return;
+        }
+
+        $this->addInterceporTrait();
     }
 }

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -65,7 +65,7 @@ final class Compiler implements CompilerInterface
         assert(class_exists($compiledClass));
         $instance = (new ReflectionClass($compiledClass))->newInstanceArgs($args);
         if ($instance instanceof WeavedInterface) {
-            $instance->_initState($bind->getBindings());
+            $instance->_setBindings($bind->getBindings());
         }
 
         assert($instance instanceof $class);

--- a/src/InterceptTrait.php
+++ b/src/InterceptTrait.php
@@ -14,12 +14,11 @@ trait InterceptTrait
     /**
      * @var MethodBindings
      * @readonly
+     * @deprecated Do not use this property directly. Use the `_initState` setter method instead for initialization.
      */
     public $bindings = [];
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     private $_isAspect = true;
 
     /**

--- a/src/InterceptTrait.php
+++ b/src/InterceptTrait.php
@@ -14,7 +14,7 @@ trait InterceptTrait
     /**
      * @var MethodBindings
      * @readonly
-     * @deprecated Do not use this property directly. Use the `_initState` setter method instead for initialization.
+     * @deprecated Do not use this property directly. Use the `_setBindings` setter method instead for initialization.
      */
     public $bindings = [];
 

--- a/src/InterceptTrait.php
+++ b/src/InterceptTrait.php
@@ -24,10 +24,10 @@ trait InterceptTrait
     /**
      * @param MethodBindings $bindings
      *
-     * @see WeavedInterface::_initState()
+     * @see WeavedInterface::_setBindings()
      * @SuppressWarnings(PHPMD.CamelCaseMethodName)
      */
-    public function _initState(array $bindings): void // @phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    public function _setBindings(array $bindings): void // @phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->bindings = $bindings;
     }

--- a/src/InterceptTrait.php
+++ b/src/InterceptTrait.php
@@ -18,7 +18,7 @@ trait InterceptTrait
      */
     public $bindings = [];
 
-    /** @var bool */
+    /** @var bool Flag controlling whether aspect interception is active */
     private $_isAspect = true;
 
     /**

--- a/src/InterceptTrait.php
+++ b/src/InterceptTrait.php
@@ -25,8 +25,9 @@ trait InterceptTrait
      * @param MethodBindings $bindings
      *
      * @see WeavedInterface::_initState()
+     * @SuppressWarnings(PHPMD.CamelCaseMethodName)
      */
-    public function _initState(array $bindings): void
+    public function _initState(array $bindings): void // @phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->bindings = $bindings;
     }

--- a/src/InterceptTrait.php
+++ b/src/InterceptTrait.php
@@ -12,21 +12,24 @@ use function call_user_func_array;
 trait InterceptTrait
 {
     /**
-     * @var InterceptTraitState
+     * @var MethodBindings
      * @readonly
-     * @psalm-suppress MissingConstructor
      */
-    private $_state;
+    public $bindings = [];
+
+    /**
+     * @var bool
+     */
+    private $_isAspect = true;
 
     /**
      * @param MethodBindings $bindings
      *
      * @see WeavedInterface::_initState()
-     * @SuppressWarnings(PHPMD.CamelCaseMethodName)
      */
-    public function _initState(array $bindings): void // phpcs:ignore
+    public function _initState(array $bindings): void
     {
-        $this->_state = new InterceptTraitState($bindings);
+        $this->bindings = $bindings;
     }
 
     /**
@@ -38,15 +41,15 @@ trait InterceptTrait
      */
     private function _intercept(string $func, array $args) // phpcs:ignore
     {
-        if (! $this->_state->isAspect) {
-            $this->_state->isAspect = true;
+        if (! $this->_isAspect) {
+            $this->_isAspect = true;
 
             return call_user_func_array([parent::class, $func], $args);
         }
 
-        $this->_state->isAspect = false;
-        $result = (new Invocation($this, $func, $args, $this->_state->bindings[$func]))->proceed();
-        $this->_state->isAspect = true;
+        $this->_isAspect = false;
+        $result = (new Invocation($this, $func, $args, $this->bindings[$func]))->proceed();
+        $this->_isAspect = true;
 
         return $result;
     }

--- a/src/InterceptTraitState.php
+++ b/src/InterceptTraitState.php
@@ -13,7 +13,7 @@ final class InterceptTraitState
      */
     public $bindings;
 
-    /** @var bool */
+    /** @var bool Flag controlling whether aspect interception is active */
     public $isAspect = true;
 
     /** @param MethodBindings $bindings */

--- a/src/WeavedInterface.php
+++ b/src/WeavedInterface.php
@@ -12,5 +12,5 @@ interface WeavedInterface
      *
      * @SuppressWarnings(PHPMD.CamelCaseMethodName)
      */
-    public function _initState(array $bindings): void; // phpcs:ignore
+    public function _setBindings(array $bindings): void; // phpcs:ignore
 }

--- a/src/Weaver.php
+++ b/src/Weaver.php
@@ -62,7 +62,7 @@ final class Weaver
             return $instance;
         }
 
-        $instance->_initState($this->bind->getBindings());
+        $instance->_setBindings($this->bind->getBindings());
         assert($instance instanceof $class);
 
         return $instance;

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -21,7 +21,6 @@ use function assert;
 use function class_exists;
 use function file_get_contents;
 use function passthru;
-use function property_exists;
 use function serialize;
 use function unserialize;
 
@@ -115,7 +114,6 @@ class CompilerTest extends TestCase
     {
         $mock = $this->compiler->newInstance(FakeMockGrandChild::class, [], $this->bind);
         assert($mock instanceof FakeMockGrandChild);
-        assert(property_exists($mock, '_state'));
         $result = $mock->returnSame(1);
         $this->assertSame(2, $result);
     }
@@ -125,7 +123,6 @@ class CompilerTest extends TestCase
         $bind = (new Bind())->bindInterceptors('passIterator', [new NullInterceptor()]);
         $mock = $this->compiler->newInstance(FakeTypedMockGrandChild::class, [], $bind);
         assert($mock instanceof FakeTypedMockGrandChild);
-        assert(property_exists($mock, '_state'));
         $result = $mock->passIterator(new ArrayIterator());
         $this->assertInstanceOf(ArrayIterator::class, $result);
     }
@@ -134,7 +131,6 @@ class CompilerTest extends TestCase
     {
         $mock = $this->compiler->newInstance(FakeMockChildChild::class, [], $this->bind);
         assert($mock instanceof FakeMockChild);
-        assert(property_exists($mock, '_state'));
         $result = $mock->returnSame(1);
         $this->assertSame(2, $result);
     }

--- a/tests/Fake/FakeWeavedClass.php
+++ b/tests/Fake/FakeWeavedClass.php
@@ -9,5 +9,5 @@ class FakeWeavedClass extends FakeClass implements WeavedInterface
     /**
      * {@inheritDoc}
      */
-    public function _initState(array $bindings): void {}
+    public function _setBindings(array $bindings): void {}
 }

--- a/tests/tmp_unerase/Ray_Aop_FakeWeaverMock_523567342.php
+++ b/tests/tmp_unerase/Ray_Aop_FakeWeaverMock_523567342.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Ray\Aop;
 
 /** doc comment of FakeMock */
-class FakeWeaverMock_523567342 extends FakeWeaverMock implements \Ray\Aop\WeavedInterface 
+class FakeWeaverMock_523567342 extends FakeWeaverMock implements \Ray\Aop\WeavedInterface
 {
-    use \Ray\Aop\Php82InterceptTrait;
+    use \Ray\Aop\ReadOnlyInterceptTrait;
     /**
      * doc comment of returnSame
      */


### PR DESCRIPTION
* Supports AOP targeting PHP 8.2 readonly classes.
* Maintains backward compatibility with existing usage that directly assigns to the `$bindings` of the AOP class, but deprecates this and recommends using the new `_setBindings()` setter method of `WeavedInterface`.

Closes #235 

## Summary by Sourcery

Deprecate direct usage of `$bindings` property in favor of the `_initState` setter. Rename `Php82InterceptTrait` to `ReadOnlyInterceptTrait`. Refactor interceptor handling for improved readonly support and simplified structure.

Enhancements:
- Deprecate the direct usage of the `$bindings` property and introduce the `_initState` setter method for initialization.
- Rename `Php82InterceptTrait` to `ReadOnlyInterceptTrait` and refactor the code to use the new trait name.
- Refactor interceptor handling to improve readonly support by replacing direct `_state` usage with `bindings` and `_isAspect`.
- Introduce `addReadOnlyIntercepterTrait()` to handle PHP readonly classes and simplify interceptor trait structure for reduced complexity and alignment with updated implementation.

## Summary by Sourcery

Deprecate direct usage of the `$bindings` property in favor of the `_initState` setter. Rename `Php82InterceptTrait` to `ReadOnlyInterceptTrait`. Refactor the interceptor handling to improve readonly support and simplify its structure by using `bindings` and `_isAspect` instead of `_state`. Introduce `addReadOnlyIntercepterTrait()` to handle readonly classes.

Enhancements:
- Deprecate direct usage of the `$bindings` property and introduce the `_initState` setter method for initialization.
- Rename `Php82InterceptTrait` to `ReadOnlyInterceptTrait` to handle readonly classes specifically.
- Refactor interceptor handling to use `bindings` and `_isAspect` instead of `_state` for improved readonly support and simplified structure.
- Introduce `addReadOnlyIntercepterTrait()` to streamline the handling of PHP readonly classes and align with the updated implementation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method for handling read-only interceptor traits.
- **Refactor**
	- Renamed interceptor trait for clarity.
	- Updated method names to enhance consistency in state and bindings management.
	- Streamlined internal logic for adding interceptor traits based on PHP version.
- **Bug Fixes**
	- Removed checks for deprecated properties in tests to align with updated state management.
- **Documentation**
	- Enhanced clarity in documentation comments for properties related to aspect interception.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->