### PR TITLE
Add deprecation stubs for PECL extension support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Ray\\Aop\\": "src/",
+            "Ray\\Aop\\": ["src/", "src-deprecated/"],
             "Ray\\ServiceLocator\\": "src-deprecated/"
         }
     },

--- a/src-deprecated/AspectPecl.php
+++ b/src-deprecated/AspectPecl.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Aop;
+
+use Ray\Aop\Exception\LogicException;
+
+/**
+ * PECL extension-based AOP aspect (deprecated)
+ *
+ * @deprecated 2.19.0 PECL extension support is deprecated and will be removed in 3.0.0.
+ *                    Use proxy-based AOP with $aspect->bind() + newInstance() instead.
+ *                    See https://github.com/ray-di/Ray.Aop/issues/242 for details.
+ */
+final class AspectPecl
+{
+    /**
+     * @throws LogicException Always throws as PECL extension is no longer supported
+     * @deprecated 2.19.0 Use $aspect->bind() + newInstance() instead
+     */
+    public function __construct()
+    {
+        throw new LogicException(
+            'PECL extension support has been removed in Ray.Aop 2.19.0. ' .
+            'Use proxy-based AOP with $aspect->bind() + newInstance() instead. ' .
+            'See https://github.com/ray-di/Ray.Aop/issues/242 for migration guide.'
+        );
+    }
+}

--- a/src-deprecated/PeclDispatcher.php
+++ b/src-deprecated/PeclDispatcher.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Aop;
+
+use Ray\Aop\Exception\LogicException;
+
+/**
+ * PECL extension dispatcher (deprecated)
+ *
+ * @deprecated 2.19.0 PECL extension support is deprecated and will be removed in 3.0.0.
+ *                    Use proxy-based AOP with $aspect->bind() + newInstance() instead.
+ *                    See https://github.com/ray-di/Ray.Aop/issues/242 for details.
+ */
+final class PeclDispatcher
+{
+    /**
+     * @param mixed ...$args Accepts any arguments for backward compatibility
+     *
+     * @throws LogicException Always throws as PECL extension is no longer supported
+     * @deprecated 2.19.0 Use proxy-based AOP instead
+     */
+    public function __construct(mixed ...$args)
+    {
+        throw new LogicException(
+            'PECL extension support has been removed in Ray.Aop 2.19.0. ' .
+            'Use proxy-based AOP with $aspect->bind() + newInstance() instead. ' .
+            'See https://github.com/ray-di/Ray.Aop/issues/242 for migration guide.'
+        );
+    }
+}


### PR DESCRIPTION
## Summary
This PR implements the deprecation strategy suggested by CodeRabbit in #248, adding backward-compatible stubs for removed PECL extension classes with clear migration guidance.

## Problem
PR #248 removed PECL extension support, but existing code using `AspectPecl` or `PeclDispatcher` would get a confusing "Class not found" error with no migration guidance.

## Solution
Add deprecation stubs in `src-deprecated/` that:
1. ✅ Maintain backward compatibility (classes still loadable)
2. ✅ Throw clear `LogicException` with migration guidance
3. ✅ Direct users to issue #242 for migration details
4. ✅ Follow semantic versioning best practices

## Changes

### New Files
- **src-deprecated/AspectPecl.php**: Deprecation stub for AspectPecl
- **src-deprecated/PeclDispatcher.php**: Deprecation stub for PeclDispatcher  

### Updated Files
- **composer.json**: Add `src-deprecated/` to autoload paths

## Error Message
```
Ray\Aop\Exception\LogicException: PECL extension support has been removed in Ray.Aop 2.19.0. 
Use proxy-based AOP with $aspect->bind() + newInstance() instead. 
See https://github.com/ray-di/Ray.Aop/issues/242 for migration guide.
```

## Benefits
- ✅ **Better UX**: Users get helpful error message instead of "Class not found"
- ✅ **SemVer compliant**: Graceful deprecation before removal in 3.0
- ✅ **Clear migration path**: Points to documentation
- ✅ **Minimal code**: Only 61 lines total
- ✅ **Easy cleanup**: Delete `src-deprecated/` in 3.0.0
- ✅ **No new exceptions**: Uses existing `LogicException`

## Testing

### Manual Test
```bash
php -r "require 'vendor/autoload.php'; new Ray\Aop\AspectPecl();"
# Output: Ray\Aop\Exception\LogicException with migration guide
```

### Automated Tests
```bash
composer tests
```
- ✅ All 113 tests pass
- ✅ Psalm error level 1: No errors
- ✅ PHPStan level max: No errors

## Future Cleanup (3.0.0)
When releasing 3.0.0:
1. Delete `src-deprecated/` directory
2. Remove `src-deprecated/` from composer.json
3. Done!

Implements CodeRabbit's suggestion from #248
Refs #242

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * PECL extension support has been removed. Users relying on the previous PECL-based implementation should migrate to proxy-based AOP using bind() with newInstance().
  * Added deprecation notices with migration guidance for outdated components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->