### PR TITLE
Fix getAnnotation() to match child classes using IS_INSTANCEOF

### DIFF
--- a/src/ReflectionClass.php
+++ b/src/ReflectionClass.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ray\Aop;
 
 use Override;
+use ReflectionAttribute;
 use ReturnTypeWillChange;
 
 use function array_map;
@@ -35,14 +36,15 @@ final class ReflectionClass extends \ReflectionClass
      * Get a specific attribute by name
      *
      * @param class-string<TAnnotation> $annotationName
+     * @param int                       $flags          Optional flags (default: ReflectionAttribute::IS_INSTANCEOF)
      *
      * @return TAnnotation|null
      *
      * @template TAnnotation of object
      */
-    public function getAnnotation(string $annotationName): object|null
+    public function getAnnotation(string $annotationName, int $flags = ReflectionAttribute::IS_INSTANCEOF): object|null
     {
-        $attributes = $this->getAttributes($annotationName);
+        $attributes = $this->getAttributes($annotationName, $flags);
         if (isset($attributes[0])) {
             return $attributes[0]->newInstance();
         }

--- a/src/ReflectionMethod.php
+++ b/src/ReflectionMethod.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ray\Aop;
 
 use Override;
+use ReflectionAttribute;
 
 use function array_map;
 
@@ -48,7 +49,7 @@ final class ReflectionMethod extends \ReflectionMethod
      *
      * @template T of object
      */
-    public function getAnnotation(string $annotationName, int $flags = 0): object|null
+    public function getAnnotation(string $annotationName, int $flags = ReflectionAttribute::IS_INSTANCEOF): object|null
     {
         $attributes = $this->getAttributes($annotationName, $flags);
         if (isset($attributes[0])) {

--- a/tests/Fake/FakeChildAttribute.php
+++ b/tests/Fake/FakeChildAttribute.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Aop;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
+final class FakeChildAttribute extends FakeParentAttribute
+{
+}

--- a/tests/Fake/FakeClassWithChildAttribute.php
+++ b/tests/Fake/FakeClassWithChildAttribute.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Aop;
+
+#[FakeChildAttribute]
+class FakeClassWithChildAttribute
+{
+    #[FakeChildAttribute]
+    public function annotatedMethod(): void
+    {
+    }
+}

--- a/tests/Fake/FakeParentAttribute.php
+++ b/tests/Fake/FakeParentAttribute.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Aop;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
+abstract class FakeParentAttribute
+{
+}

--- a/tests/Fake/FakeParentAttribute.php
+++ b/tests/Fake/FakeParentAttribute.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Ray\Aop;
 
-use Attribute;
-
-#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
 abstract class FakeParentAttribute
 {
 }

--- a/tests/ReflectionClassTest.php
+++ b/tests/ReflectionClassTest.php
@@ -60,4 +60,11 @@ class ReflectionClassTest extends TestCase
     {
         $this->assertInstanceOf(ReflectionClass::class, (new ReflectionClass(FakeMockChild::class))->getParentClass());
     }
+
+    public function testGetAnnotationMatchesChildClass(): void
+    {
+        $class = new ReflectionClass(FakeClassWithChildAttribute::class);
+        $annotation = $class->getAnnotation(FakeParentAttribute::class);
+        $this->assertInstanceOf(FakeChildAttribute::class, $annotation);
+    }
 }

--- a/tests/ReflectionMethodTest.php
+++ b/tests/ReflectionMethodTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Aop;
+
+use PHPUnit\Framework\TestCase;
+
+class ReflectionMethodTest extends TestCase
+{
+    public function testGetAnnotationMatchesChildClass(): void
+    {
+        $method = new ReflectionMethod(FakeClassWithChildAttribute::class, 'annotatedMethod');
+        $annotation = $method->getAnnotation(FakeParentAttribute::class);
+        $this->assertInstanceOf(FakeChildAttribute::class, $annotation);
+    }
+}


### PR DESCRIPTION
## Summary
- Changed default `$flags` parameter from `0` to `ReflectionAttribute::IS_INSTANCEOF` in `ReflectionClass::getAnnotation()` and `ReflectionMethod::getAnnotation()`
- Restores the instanceof matching behavior that was broken in 2.18.0

## Test plan
- [x] Added `testGetAnnotationMatchesChildClass()` tests for both ReflectionClass and ReflectionMethod
- [x] All 164 tests pass
- [x] Static analysis (Psalm + PHPStan) reports no errors

Fixes #254

## Summary by Sourcery

Restore default instanceof-based attribute matching in reflection annotation helpers.

Bug Fixes:
- Ensure ReflectionClass::getAnnotation() matches child attributes when queried by a parent attribute class.
- Ensure ReflectionMethod::getAnnotation() matches child attributes when queried by a parent attribute class.

Tests:
- Add fake parent/child attribute fixtures and annotated class/method for inheritance-based annotation tests.
- Add tests verifying getAnnotation() returns a child attribute instance when requested with the parent attribute type for both classes and methods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated reflection methods to support attribute matching with inheritance. The `getAnnotation()` method now accepts an optional flags parameter, enabling instance-of checks for attribute resolution by default.

* **Tests**
  * Added test coverage for attribute inheritance matching functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->