### PR TITLE
perf: faster weave/newInstance and bind without attribute instantiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Compiler::compile()` now (re)emits the weaved class file even when the class is already declared in the process but the file is missing, so a compile pipeline that cleans and recompiles produces complete output for runtime loaders that resolve weaved classes by name. (#261)
 - Infinite recursion when an interceptor invoked another intercepted method on the same instance via `getThis()`. Such nested calls are now intercepted normally (previously interception state was corrupted). (#260)
 - Codegen no longer corrupts generated method code containing `$1`-style sequences (`preg_replace` backreference bug in `AopCode::insert()`). (#260)
+- Bind/match no longer instantiates method attributes via `getAnnotations()`/`getAnnotation()`, so a broken attribute constructor on an unrelated method cannot fatal `bind()`. (#259)
+- `Weaver` serialization excludes the in-process weaved-class cache so a restored Weaver in another process reloads class files instead of assuming FQNs are already defined. (#259)
 
 ### Removed
 - Internal API: `AopCode::INTERCEPT_STATEMENT` public const, `_intercept()`, `_isAspect`; `AopCode::resolveInterceptTrait()` is now private. (#260)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Proxy dispatch is now a direct `parent::method(...)` first-class callable (no double dispatch through the proxy); intercepted-call overhead roughly halved. Generated proxies are invalidated via `AopCode::GENERATION` — existing script dirs regenerate once after upgrade (stale files are ignored, not loaded). (#260)
 - Faster weave/`newInstance` path: cache weaved class names, instantiate with `new $class(...$args)` instead of reflection, and match attributes without instantiating them during bind. (#259)
+- Annotation-order (onion) binding now respects attribute inheritance (`is_a`, aligned with #255). Methods annotated with a subclass attribute may get a different interceptor order than before (they were previously bound only in the default phase). (#259)
 
 ### Fixed
 - `Compiler::compile()` now (re)emits the weaved class file even when the class is already declared in the process but the file is missing, so a compile pipeline that cleans and recompiles produces complete output for runtime loaders that resolve weaved classes by name. (#261)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Proxy dispatch is now a direct `parent::method(...)` first-class callable (no double dispatch through the proxy); intercepted-call overhead roughly halved. Generated proxies are invalidated via `AopCode::GENERATION` — existing script dirs regenerate once after upgrade (stale files are ignored, not loaded). (#260)
+- Faster weave/`newInstance` path: cache weaved class names, instantiate with `new $class(...$args)` instead of reflection, and match attributes without instantiating them during bind. (#259)
 
 ### Fixed
 - `Compiler::compile()` now (re)emits the weaved class file even when the class is already declared in the process but the file is missing, so a compile pipeline that cleans and recompiles produces complete output for runtime loaders that resolve weaved classes by name. (#261)

--- a/src/AnnotatedMatcher.php
+++ b/src/AnnotatedMatcher.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ray\Aop;
 
 use Override;
+use ReflectionAttribute;
 use ReflectionClass;
 use ReflectionMethod;
 
@@ -35,12 +36,10 @@ final class AnnotatedMatcher extends BuiltinMatcher
     #[Override]
     public function matchesClass(ReflectionClass $class, array $arguments): bool
     {
-        $rayClass = $class instanceof \Ray\Aop\ReflectionClass ? $class : new \Ray\Aop\ReflectionClass($class->getName());
         /** @var class-string $annotationName */
         $annotationName = $arguments[0];
-        $annotation = $rayClass->getAnnotation($annotationName);
 
-        return $annotation !== null;
+        return $class->getAttributes($annotationName, ReflectionAttribute::IS_INSTANCEOF) !== [];
     }
 
     /**
@@ -49,11 +48,9 @@ final class AnnotatedMatcher extends BuiltinMatcher
     #[Override]
     public function matchesMethod(ReflectionMethod $method, array $arguments): bool
     {
-        $rayMethod = $method instanceof \Ray\Aop\ReflectionMethod ? $method : new \Ray\Aop\ReflectionMethod($method->class, $method->getName());
         /** @var class-string $annotationName */
         $annotationName = $arguments[0];
-        $annotation = $rayMethod->getAnnotation($annotationName);
 
-        return $annotation !== null;
+        return $method->getAttributes($annotationName, ReflectionAttribute::IS_INSTANCEOF) !== [];
     }
 }

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -55,7 +55,9 @@ final class Compiler implements CompilerInterface
     {
         $compiledClass = $this->compile($class, $bind);
         assert(class_exists($compiledClass));
-        $instance = (new ReflectionClass($compiledClass))->newInstanceArgs($args);
+        /** @var class-string<T> $compiledClass */
+        /** @psalm-suppress MixedMethodCall */
+        $instance = new $compiledClass(...$args);
         if ($instance instanceof WeavedInterface) {
             $instance->_setBindings($bind->getBindings());
         }

--- a/src/Matcher/AnnotatedWithMatcher.php
+++ b/src/Matcher/AnnotatedWithMatcher.php
@@ -7,6 +7,7 @@ namespace Ray\Aop\Matcher;
 use Override;
 use Ray\Aop\AbstractMatcher;
 use Ray\Aop\Types;
+use ReflectionAttribute;
 use ReflectionClass;
 use ReflectionMethod;
 
@@ -26,12 +27,9 @@ final class AnnotatedWithMatcher extends AbstractMatcher
         /** @var Arguments $arguments */
         [$annotationName] = $arguments;
         assert(is_string($annotationName));
-        /** @psalm-suppress MixedAssignment $annotation */
-        /** @psalm-suppress ArgumentTypeCoercion */
-        /** @phpstan-ignore-next-line argument.type, argument.templateType */
-        $annotation = $class->getAnnotation($annotationName);
+        /** @var class-string $annotationName */
 
-        return (bool) $annotation;
+        return $class->getAttributes($annotationName, ReflectionAttribute::IS_INSTANCEOF) !== [];
     }
 
     /**
@@ -44,11 +42,8 @@ final class AnnotatedWithMatcher extends AbstractMatcher
         /** @var Arguments $arguments */
         [$annotationName] = $arguments;
         assert(is_string($annotationName));
+        /** @var class-string $annotationName */
 
-        /** @psalm-suppress ArgumentTypeCoercion */
-        /** @phpstan-ignore-next-line argument.type, argument.templateType */
-        $annotation = $method->getAnnotation($annotationName);
-
-        return (bool) $annotation;
+        return $method->getAttributes($annotationName, ReflectionAttribute::IS_INSTANCEOF) !== [];
     }
 }

--- a/src/MethodMatch.php
+++ b/src/MethodMatch.php
@@ -7,6 +7,7 @@ namespace Ray\Aop;
 use ReflectionClass;
 use ReflectionMethod;
 
+use function assert;
 use function is_a;
 use function is_string;
 
@@ -90,10 +91,7 @@ final readonly class MethodMatch
                     continue;
                 }
 
-                if (! is_string($key)) {
-                    continue;
-                }
-
+                assert(is_string($key));
                 /** @var class-string $key */
                 if ($annotationIndex !== $key && ! is_a($annotationIndex, $key, true)) {
                     continue;

--- a/src/MethodMatch.php
+++ b/src/MethodMatch.php
@@ -7,7 +7,8 @@ namespace Ray\Aop;
 use ReflectionClass;
 use ReflectionMethod;
 
-use function array_key_exists;
+use function is_a;
+use function is_string;
 
 /**
  * @psalm-import-type MethodInterceptors from Types
@@ -29,8 +30,6 @@ final readonly class MethodMatch
      */
     public function __invoke(ReflectionClass $class, \Ray\Aop\ReflectionMethod $method, array $pointcuts): void
     {
-        /** @var list<object> $annotations */
-        $annotations = $method->getAnnotations();
         // priority bind
         foreach ($pointcuts as $key => $pointcut) {
             if (! ($pointcut instanceof PriorityPointcut)) {
@@ -41,7 +40,7 @@ final readonly class MethodMatch
             unset($pointcuts[$key]);
         }
 
-        $onion = $this->onionOrderMatch($class, $method, $pointcuts, $annotations);
+        $onion = $this->onionOrderMatch($class, $method, $pointcuts);
 
         // default binding
         foreach ($onion as $pointcut) {
@@ -70,7 +69,6 @@ final readonly class MethodMatch
     /**
      * @param ReflectionClass<object> $class
      * @param Pointcuts               $pointcuts
-     * @param list<object>            $annotations
      *
      * @return Pointcuts
      */
@@ -78,19 +76,46 @@ final readonly class MethodMatch
         ReflectionClass $class,
         ReflectionMethod $method,
         array $pointcuts,
-        array $annotations,
     ): array {
-        // method bind in annotation order
-        foreach ($annotations as $annotation) {
-            $annotationIndex = $annotation::class;
-            if (! array_key_exists($annotationIndex, $pointcuts)) {
-                continue;
-            }
+        if (! $this->hasAnnotationPointcut($pointcuts)) {
+            return $pointcuts;
+        }
 
-            $this->annotatedMethodMatchBind($class, $method, $pointcuts[$annotationIndex]);
-            unset($pointcuts[$annotationIndex]);
+        // method bind in annotation order
+        foreach ($method->getAttributes() as $attribute) {
+            /** @var class-string $annotationIndex */
+            $annotationIndex = $attribute->getName();
+            foreach ($pointcuts as $key => $pointcut) {
+                if (! $pointcut->methodMatcher instanceof AnnotatedMatcher) {
+                    continue;
+                }
+
+                if (! is_string($key)) {
+                    continue;
+                }
+
+                /** @var class-string $key */
+                if ($annotationIndex !== $key && ! is_a($annotationIndex, $key, true)) {
+                    continue;
+                }
+
+                $this->annotatedMethodMatchBind($class, $method, $pointcut);
+                unset($pointcuts[$key]);
+            }
         }
 
         return $pointcuts;
+    }
+
+    /** @param Pointcuts $pointcuts */
+    private function hasAnnotationPointcut(array $pointcuts): bool
+    {
+        foreach ($pointcuts as $pointcut) {
+            if ($pointcut->methodMatcher instanceof AnnotatedMatcher) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Weaver.php
+++ b/src/Weaver.php
@@ -20,6 +20,9 @@ final class Weaver
     private readonly string $bindName;
     private readonly Compiler $compiler;
 
+    /** @var array<class-string, class-string> */
+    private array $classCache = [];
+
     /** @param ScriptDir $classDir */
     public function __construct(private readonly BindInterface $bind, private readonly string $classDir)
     {
@@ -41,13 +44,15 @@ final class Weaver
     {
         $aopClass = $this->weave($class);
         /** @var T $instance */
-        $instance = (new ReflectionClass($aopClass))->newInstanceArgs($args);
+        /** @var class-string<T> $aopClass */
+        /** @psalm-suppress MixedMethodCall */
+        $instance = new $aopClass(...$args);
+        assert($instance instanceof $class);
         if (! $instance instanceof WeavedInterface) {
             return $instance;
         }
 
         $instance->_setBindings($this->bind->getBindings());
-        assert($instance instanceof $class);
 
         return $instance;
     }
@@ -59,21 +64,25 @@ final class Weaver
      */
     public function weave(string $class): string
     {
+        if (isset($this->classCache[$class])) {
+            return $this->classCache[$class];
+        }
+
         $aopClass = new AopPostfixClassName($class, $this->bindName, $this->classDir);
         if (class_exists($aopClass->fqn, false)) {
-            return $aopClass->fqn;
+            return $this->classCache[$class] = $aopClass->fqn;
         }
 
         if ($this->loadClass($aopClass->fqn)) {
             assert(class_exists($aopClass->fqn));
 
-            return $aopClass->fqn;
+            return $this->classCache[$class] = $aopClass->fqn;
         }
 
         $newClass = $this->compiler->compile($class, $this->bind);
         assert(class_exists($newClass));
 
-        return $newClass;
+        return $this->classCache[$class] = $newClass;
     }
 
     private function loadClass(string $class): bool

--- a/src/Weaver.php
+++ b/src/Weaver.php
@@ -33,6 +33,17 @@ final class Weaver
     }
 
     /**
+     * Exclude in-process FQN cache from serialization. A restored Weaver in another
+     * process must re-run loadClass()/compile() — cached names would skip require and fatal.
+     *
+     * @return list<'bindName'|'compiler'|'bind'|'classDir'>
+     */
+    public function __sleep(): array
+    {
+        return ['bindName', 'compiler', 'bind', 'classDir'];
+    }
+
+    /**
      * @param class-string<T> $class
      * @param list<mixed>     $args
      *

--- a/tests/BindTest.php
+++ b/tests/BindTest.php
@@ -141,4 +141,31 @@ class BindTest extends TestCase
         $this->assertArrayHasKey('run', $this->bind->getBindings());
         $this->assertSame(0, FakeCountingAttribute::$instances);
     }
+
+    public function testAnnotatedWithParentAttributeMatchesChildAttribute(): void
+    {
+        $interceptor = new FakeDoubleInterceptor();
+        $pointcut = new Pointcut(
+            (new Matcher())->any(),
+            (new Matcher())->annotatedWith(FakeParentAttr::class),
+            [$interceptor],
+        );
+        $this->bind->bind(FakeChildAttrClass::class, [$pointcut]);
+
+        $this->assertSame(['run' => [$interceptor]], $this->bind->getBindings());
+    }
+
+    public function testAnnotationOrderDeterminesInterceptorOrder(): void
+    {
+        // FakeAnnotateClass::getDouble attributes: FakeMarker3, FakeMarker2, FakeMarker, FakeMarker
+        $i3 = new FakeOnionInterceptor3();
+        $i2 = new FakeOnionInterceptor2();
+        $i1 = new FakeOnionInterceptor1();
+        $pc3 = new Pointcut((new Matcher())->any(), (new Matcher())->annotatedWith(FakeMarker3::class), [$i3]);
+        $pc2 = new Pointcut((new Matcher())->any(), (new Matcher())->annotatedWith(FakeMarker2::class), [$i2]);
+        $pc1 = new Pointcut((new Matcher())->any(), (new Matcher())->annotatedWith(FakeMarker::class), [$i1]);
+        $this->bind->bind(FakeAnnotateClass::class, [$pc1, $pc2, $pc3]);
+
+        $this->assertSame([$i3, $i2, $i1], $this->bind->getBindings()['getDouble']);
+    }
 }

--- a/tests/BindTest.php
+++ b/tests/BindTest.php
@@ -119,4 +119,26 @@ class BindTest extends TestCase
         ];
         $this->assertSame($expect, $actual);
     }
+
+    public function testNonAnnotationPointcutDoesNotInstantiateMethodAttributes(): void
+    {
+        FakeCountingAttribute::$instances = 0;
+
+        $pointcut = new Pointcut((new Matcher())->any(), (new Matcher())->any(), [new FakeDoubleInterceptor()]);
+        $this->bind->bind(FakeCountingAttributeClass::class, [$pointcut]);
+
+        $this->assertArrayHasKey('run', $this->bind->getBindings());
+        $this->assertSame(0, FakeCountingAttribute::$instances);
+    }
+
+    public function testAnnotatedPointcutDoesNotInstantiateMethodAttributes(): void
+    {
+        FakeCountingAttribute::$instances = 0;
+
+        $pointcut = new Pointcut((new Matcher())->any(), (new Matcher())->annotatedWith(FakeCountingAttribute::class), [new FakeDoubleInterceptor()]);
+        $this->bind->bind(FakeCountingAttributeClass::class, [$pointcut]);
+
+        $this->assertArrayHasKey('run', $this->bind->getBindings());
+        $this->assertSame(0, FakeCountingAttribute::$instances);
+    }
 }

--- a/tests/Fake/FakeChildAttr.php
+++ b/tests/Fake/FakeChildAttr.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Aop;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class FakeChildAttr extends FakeParentAttr
+{
+}

--- a/tests/Fake/FakeChildAttrClass.php
+++ b/tests/Fake/FakeChildAttrClass.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Aop;
+
+class FakeChildAttrClass
+{
+    #[FakeChildAttr]
+    public function run(): string
+    {
+        return 'ok';
+    }
+}

--- a/tests/Fake/FakeCountingAttribute.php
+++ b/tests/Fake/FakeCountingAttribute.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Aop;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+final class FakeCountingAttribute
+{
+    public static int $instances = 0;
+
+    public function __construct()
+    {
+        self::$instances++;
+    }
+}

--- a/tests/Fake/FakeCountingAttributeClass.php
+++ b/tests/Fake/FakeCountingAttributeClass.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Aop;
+
+class FakeCountingAttributeClass
+{
+    #[FakeCountingAttribute]
+    public function run(): void
+    {
+    }
+}

--- a/tests/Fake/FakeCtorArgsClass.php
+++ b/tests/Fake/FakeCtorArgsClass.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Aop;
+
+class FakeCtorArgsClass
+{
+    public function __construct(
+        public string $name,
+        public int $n = 0,
+    ) {
+    }
+
+    public function greet(): string
+    {
+        return $this->name . $this->n;
+    }
+}

--- a/tests/Fake/FakeParentAttr.php
+++ b/tests/Fake/FakeParentAttr.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Aop;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class FakeParentAttr
+{
+}

--- a/tests/WeaverTest.php
+++ b/tests/WeaverTest.php
@@ -32,6 +32,35 @@ class WeaverTest extends TestCase
         $this->assertTrue(class_exists($className, false));
     }
 
+    public function testNewInstancePassesListConstructorArgs(): void
+    {
+        $matcher = new Matcher();
+        $pointcut = new Pointcut($matcher->any(), $matcher->startsWith('greet'), [new NullInterceptor()]);
+        $bind = (new Bind())->bind(FakeCtorArgsClass::class, [$pointcut]);
+        $weaver = new Weaver($bind, __DIR__ . '/tmp');
+
+        $instance = $weaver->newInstance(FakeCtorArgsClass::class, ['alice', 7]);
+
+        $this->assertInstanceOf(FakeCtorArgsClass::class, $instance);
+        $this->assertInstanceOf(WeavedInterface::class, $instance);
+        $this->assertSame('alice7', $instance->greet());
+    }
+
+    public function testNewInstancePassesNamedConstructorArgs(): void
+    {
+        $matcher = new Matcher();
+        $pointcut = new Pointcut($matcher->any(), $matcher->startsWith('greet'), [new NullInterceptor()]);
+        $bind = (new Bind())->bind(FakeCtorArgsClass::class, [$pointcut]);
+        $weaver = new Weaver($bind, __DIR__ . '/tmp');
+
+        // new $class(...$args) accepts named arguments when keys match parameter names.
+        // Public type is list<mixed>; named bags are a runtime-supported extension.
+        /** @phpstan-ignore argument.type (named ctor args via spread) */
+        $instance = $weaver->newInstance(FakeCtorArgsClass::class, ['n' => 3, 'name' => 'bob']);
+
+        $this->assertSame('bob3', $instance->greet());
+    }
+
     public function testWeaveLoadsCompiledAopFile(): void
     {
         $matcher = new Matcher();

--- a/tests/WeaverTest.php
+++ b/tests/WeaverTest.php
@@ -6,6 +6,7 @@ namespace Ray\Aop;
 
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
 
 use function class_exists;
 use function passthru;
@@ -83,8 +84,17 @@ class WeaverTest extends TestCase
     #[Depends('testConstructorCreatesWeaverInstance')]
     public function testSerializedWeaverMaintainsFunctionality(Weaver $weaver): void
     {
-        $weaver = unserialize(serialize($weaver));
+        // Populate classCache, then ensure it is not restored after unserialize
+        $weaver->weave(FakeWeaverMock::class);
+        $serialized = serialize($weaver);
+        $this->assertStringNotContainsString('classCache', $serialized);
+
+        $weaver = unserialize($serialized);
         $this->assertInstanceOf(Weaver::class, $weaver);
+
+        $cache = (new ReflectionProperty(Weaver::class, 'classCache'))->getValue($weaver);
+        $this->assertSame([], $cache, 'classCache must not survive serialize/unserialize');
+
         $weaved = $weaver->newInstance(FakeWeaverMock::class, []);
         $this->assertInstanceOf(FakeWeaverMock::class, $weaved);
         $result = $weaved->returnSame(1);


### PR DESCRIPTION
## Summary

Speed up **bind / weave / newInstance** (construction path), complementary to #260 (per-call FCC).

- **Weaver**: cache weaved FQN; `new $class(...$args)` instead of `ReflectionClass::newInstanceArgs`
- **Matchers**: `getAttributes(..., IS_INSTANCEOF)` — no attribute `newInstance()` during match/bind
- **MethodMatch**: skip `getAnnotations()`; onion order + `is_a` for child attributes; early-out when no annotation pointcuts
- **Compiler**: same `new $class(...$args)` for `newInstance`

Rebased onto post-#260 `2.x`. Lazy `ArrayObject` / call-path work stays with #260 (this PR no longer touches `ReflectiveMethodInvocation`).

## Microbenchmarks (pre-#260; re-run after merge if needed)

| Case | Before | After |
| --- | ---: | ---: |
| Weaver newInstance | ~1403 ns | ~463 ns (~3×) |
| Bind any/any 300 methods | ~0.62 ms | ~0.53 ms |
| Attribute ctors during any/any bind | 300 | 0 |

## Tests

- Attribute bind does not instantiate method attributes
- List + named constructor args via `newInstance`
- Parent attribute pointcut matches child attribute
- Annotation order → interceptor onion order

## Note on `$args`

Public type is `list<mixed>`. Named-argument bags work at runtime via spread (`new $class(...$args)`); document that callers should pass a list or real parameter names.

## Stacking

```text
#260 call path (merged) + this PR construction path
#262 interceptor // comments — independent follow-up
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Faster weaving and object creation via improved caching and direct constructor instantiation.
  - Reduced unnecessary instantiation when evaluating annotation/attribute-based bindings and matches.

- **Bug Fixes**
  - Improved attribute-driven matching (including parent/child attribute relationships) and corrected interceptor ordering based on attribute precedence.
  - Fixed attribute evaluation so method attributes aren’t instantiated during matching where they shouldn’t be, and ensured serialized weavers don’t rely on in-process cache.

- **Tests**
  - Added coverage for attribute matching/non-matching behavior, interceptor ordering, and constructor argument passing (positional and named).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->