### PR TITLE
fix: re-emit weaved class file when declared in-process but missing on disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- `Compiler::compile()` now (re)emits the weaved class file even when the class is already declared in the process but the file is missing, so a compile pipeline that cleans and recompiles produces complete output for runtime loaders that resolve weaved classes by name.
+
 ## [2.19.1] - 2026-01-24
 
 ### Fixed

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -87,7 +87,7 @@ final class Compiler implements CompilerInterface
         $file = $this->getFileName($className->fqn);
         if (! class_exists($className->fqn, false) || ! file_exists($file)) {
             try {
-                $this->requireFile($className, new ReflectionClass($class), $bind);
+                $this->requireFile($className, new ReflectionClass($class), $bind, $file);
                 // @codeCoverageIgnoreStart
             } catch (ParseError) {
                 $msg = sprintf('class:%s Compilation failed in Ray.Aop. This is most likely a bug in Ray.Aop, please report it to the issue. https://github.com/ray-di/Ray.Aop/issues', $class);
@@ -128,9 +128,8 @@ final class Compiler implements CompilerInterface
     }
 
     /** @param ReflectionClass<object> $sourceClass */
-    private function requireFile(AopPostfixClassName $className, ReflectionClass $sourceClass, BindInterface $bind): void
+    private function requireFile(AopPostfixClassName $className, ReflectionClass $sourceClass, BindInterface $bind, string $file): void
     {
-        $file = $this->getFileName($className->fqn);
         if (! file_exists($file)) {
             $code = new AopCode(new MethodSignatureString());
             $aopCode = $code->generate($sourceClass, $bind, $className->postFix);

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -84,7 +84,8 @@ final class Compiler implements CompilerInterface
         }
 
         $className = new AopPostfixClassName($class, (string) $bind, $this->classDir);
-        if (! class_exists($className->fqn, false)) {
+        $file = $this->getFileName($className->fqn);
+        if (! class_exists($className->fqn, false) || ! file_exists($file)) {
             try {
                 $this->requireFile($className, new ReflectionClass($class), $bind);
                 // @codeCoverageIgnoreStart

--- a/tests/WeavedFileReemissionTest.php
+++ b/tests/WeavedFileReemissionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Aop;
+
+use PHPUnit\Framework\TestCase;
+
+use function class_exists;
+use function file_exists;
+use function glob;
+use function mkdir;
+use function rmdir;
+use function str_replace;
+use function uniqid;
+use function unlink;
+
+/**
+ * compile() must (re)emit the weaved class file even when the class is already
+ * declared in the process but the file has been removed — e.g. a compile
+ * pipeline that cleans the script dir and recompiles. The file is needed by
+ * runtime loaders that resolve the weaved class by name.
+ */
+final class WeavedFileReemissionTest extends TestCase
+{
+    public function testReemitsWeavedFileWhenClassDeclaredButFileDeleted(): void
+    {
+        $tmpDir = __DIR__ . '/tmp/weaved-reemission-' . uniqid('', true);
+        @mkdir($tmpDir, 0777, true);
+
+        try {
+            $compiler = new Compiler($tmpDir);
+            $bind = (new Bind())->bindInterceptors('returnSame', [new FakeDoubleInterceptor()]);
+
+            // First weave: writes the file and declares the class in-process.
+            $fqn = $compiler->compile(FakeMock::class, $bind);
+            $file = $tmpDir . '/' . str_replace('\\', '_', $fqn) . '.php';
+            $this->assertTrue(file_exists($file), 'first weave must write the file');
+            $this->assertTrue(class_exists($fqn, false), 'first weave declares the class');
+
+            // Simulate a compile-pipeline clean step: the file is removed while
+            // the class stays declared in the process.
+            unlink($file);
+            $this->assertFalse(file_exists($file));
+
+            // Re-weave: must re-emit the file even though the class is declared.
+            $compiler->compile(FakeMock::class, $bind);
+            $this->assertTrue(file_exists($file), 're-weave must re-emit the weaved file when it is missing');
+        } finally {
+            foreach (glob($tmpDir . '/*') ?: [] as $f) {
+                @unlink($f);
+            }
+
+            @rmdir($tmpDir);
+        }
+    }
+}

--- a/tests/WeavedFileReemissionTest.php
+++ b/tests/WeavedFileReemissionTest.php
@@ -46,6 +46,7 @@ final class WeavedFileReemissionTest extends TestCase
             // Re-weave: must re-emit the file even though the class is declared.
             $compiler->compile(FakeMock::class, $bind);
             $this->assertTrue(file_exists($file), 're-weave must re-emit the weaved file when it is missing');
+            $this->assertTrue(class_exists($fqn, false), 're-weave must not unset the already-declared class');
         } finally {
             foreach (glob($tmpDir . '/*') ?: [] as $f) {
                 @unlink($f);


### PR DESCRIPTION
## Summary

`Ray\Aop\Compiler::compile()` skipped `requireFile()` whenever the weaved class was already declared in the process — **even if the generated file had been removed**. A compile pipeline that weaves, cleans the script dir, and recompiles then shipped output without the weaved class definition files, and runtime loaders that resolve weaved classes by name cannot regenerate them (there is no AOP weaver at runtime), so resolving an intercepted resource throws `Class not found`.

### Repro (BEAR.Package AOT)

`bin/compile.php` does `Compiler::fromInjector(Injector::getInstance($context), $context)()`:

1. `Injector::getInstance()` weaves every intercepted binding → writes the weaved `_<postfix>.php` files **and declares the classes in-process**.
2. `Compiler::__invoke()` → `clean()` wipes the script dir (files gone, classes stay declared).
3. The recompile calls `compile()` again, but `class_exists($fqn, false)` is `true` (declared in step 1) → `requireFile()` is skipped → **the weaved files are never re-emitted**.

Result: the shipped `di/` is missing weaved class files (e.g. `FakeDep_3881589280.php`, `…Resource_App_Emb_….php` for `@Embed`). Booting from it with `CompiledInjector` and resolving an intercepted resource:

```
Error: Class "FakeVendor\HelloWorld\FakeDep_3881589280" not found
```

`@Embed` (HATEOAS) weaves resources, so this is not an edge case.

## Fix

`compile()` is documented `@sideEffect Generates a new class file`. Always emit the file when it is missing, regardless of whether the class is already declared:

```diff
  $className = new AopPostfixClassName($class, (string) $bind, $this->classDir);
- if (! class_exists($className->fqn, false)) {
+ $file = $this->getFileName($className->fqn);
+ if (! class_exists($className->fqn, false) || ! file_exists($file)) {
      try {
          $this->requireFile($className, new ReflectionClass($class), $bind);
```

`requireFile()` writes the file (guarded by `if (! file_exists($file))`) then `require_once`s it. `require_once` is a no-op when the file was already loaded, so re-emitting after the class is declared carries no redeclaration risk.

## Why this layer

The weaved class file is part of the compiled-output contract. The bug is that `compile()` stops honouring it once the class is declared, which makes the output depend on in-process state rather than on what is on disk. This is the AOP analogue of ray-di/Ray.Compiler#136 (compiled scripts must not bake in-process/build-time state). It unblocks reuse of AOT output for immutable images / read-only filesystems (BEAR.Package #483).

## Test

`tests/WeavedFileReemissionTest.php`: weave → delete the file → re-weave → assert the file is re-emitted. Fails without the fix (`false is true`), passes with it.

## Checks

- `phpcs`, `phpstan`, `psalm`: clean
- `phpunit`: 165 tests (164 existing + new), 296 assertions — no regression
- Verified end-to-end in BEAR.Package: AOT output goes 116 → 120 scripts (weaved files present); a fresh-process prod boot resolves the intercepted resource that previously threw `Class not found`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed recompilation to recreate the generated (weaved) class file when the class is already loaded but the output file is missing.
  * Improved reliability for clean-and-recompile flows and runtime class resolution.
* **Tests**
  * Added coverage verifying missing generated files are restored on recompilation.
* **Documentation**
  * Updated the unreleased changelog entry describing the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->