### PR TITLE
feat: document bound interceptors in weaved method comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Proxy dispatch is now a direct `parent::method(...)` first-class callable (no double dispatch through the proxy); intercepted-call overhead roughly halved. Generated proxies are invalidated via `AopCode::GENERATION` — existing script dirs regenerate once after upgrade (stale files are ignored, not loaded). (#260)
 - Faster weave/`newInstance` path: cache weaved class names, instantiate with `new $class(...$args)` instead of reflection, and match attributes without instantiating them during bind. (#259)
 - Annotation-order (onion) binding now respects attribute inheritance (`is_a`, aligned with #255). Methods annotated with a subclass attribute may get a different interceptor order than before (they were previously bound only in the default phase). (#259)
+- Weaved methods include an always-on `//` comment listing bound interceptor short class names (self-documenting generated code; no runtime cost). (#262)
 
 ### Fixed
 - `Compiler::compile()` now (re)emits the weaved class file even when the class is already declared in the process but the file is missing, so a compile pipeline that cleans and recompiles produces complete output for runtime loaders that resolve weaved classes by name. (#261)

--- a/infection.json5
+++ b/infection.json5
@@ -16,8 +16,8 @@
     },
     "tmpDir": "build/infection",
     "timeout": 60,
-    "minMsi": 80,
-    "minCoveredMsi": 83,
+    "minMsi": 83,
+    "minCoveredMsi": 85,
     "testFramework": "phpunit",
     "phpUnit": {
         "configDir": ".",

--- a/src/AopCode.php
+++ b/src/AopCode.php
@@ -11,6 +11,7 @@ use ReflectionUnionType;
 
 use function file_get_contents;
 use function implode;
+use function is_object;
 use function preg_replace;
 use function preg_replace_callback;
 use function rtrim;
@@ -252,7 +253,7 @@ PHP;
     {
         $names = [];
         foreach ($interceptors as $interceptor) {
-            $fqn = $interceptor::class;
+            $fqn = is_object($interceptor) ? $interceptor::class : $interceptor;
             $pos = strrpos($fqn, '\\');
             $names[] = $pos === false ? $fqn : substr($fqn, $pos + 1);
         }

--- a/src/AopCode.php
+++ b/src/AopCode.php
@@ -223,7 +223,7 @@ PHP;
             }
 
             $return = $isVoid ? '' : 'return ';
-            /** @var list<object> $interceptors */
+            /** @var list<object|class-string> $interceptors */
             $interceptors = $bindings[$methodName];
             $body = sprintf(
                 $template,
@@ -247,7 +247,7 @@ PHP;
     /**
      * Short class names for the always-on weaved-method comment (self-documenting bind).
      *
-     * @param list<object> $interceptors
+     * @param list<object|class-string> $interceptors
      */
     private function interceptorShortNames(array $interceptors): string
     {

--- a/src/AopCode.php
+++ b/src/AopCode.php
@@ -9,8 +9,6 @@ use ReflectionClass;
 use ReflectionNamedType;
 use ReflectionUnionType;
 
-use function array_flip;
-use function array_keys;
 use function file_get_contents;
 use function implode;
 use function preg_replace;
@@ -18,6 +16,7 @@ use function preg_replace_callback;
 use function rtrim;
 use function sprintf;
 use function strrpos;
+use function substr;
 use function substr_replace;
 use function token_get_all;
 use function trim;
@@ -35,20 +34,23 @@ use const T_STRING;
 final class AopCode
 {
     /** Code generation version — bump on codegen changes to invalidate cached proxies */
-    public const GENERATION = 5;
+    public const GENERATION = 6;
 
     /**
      * Template for direct parent-FCC dispatch (no _intercept, no _isAspect flag).
+     * Leading // line lists interceptor short class names (self-documenting weaved code).
      * Two statements: build MethodInvocation, then proceed (compact, no blank line).
      */
     // Closing delimiter at column 0 so body keeps 8-space method indent (PSR12)
     private const INVOKE_TEMPLATE = <<<'PHP'
+        // %s
         $invocation = new \Ray\Aop\ReflectiveMethodInvocation($this, '%s', func_get_args(), $this->bindings['%s'], parent::%s(...));
         %s$invocation->proceed();
 PHP;
 
     /** Template for readonly classes (bindings accessed via $_state) */
     private const INVOKE_READONLY_TEMPLATE = <<<'PHP'
+        // %s
         $invocation = new \Ray\Aop\ReflectiveMethodInvocation($this, '%s', func_get_args(), $this->_state->bindings['%s'], parent::%s(...));
         %s$invocation->proceed();
 PHP;
@@ -201,7 +203,7 @@ PHP;
     /** @param ReflectionClass<object> $class */
     private function addMethods(ReflectionClass $class, BindInterface $bind, bool $isReadOnly): void
     {
-        $bindings = array_flip(array_keys($bind->getBindings()));
+        $bindings = $bind->getBindings();
         $template = $isReadOnly ? self::INVOKE_READONLY_TEMPLATE : self::INVOKE_TEMPLATE;
 
         $parentMethods = $class->getMethods();
@@ -220,8 +222,11 @@ PHP;
             }
 
             $return = $isVoid ? '' : 'return ';
+            /** @var list<object> $interceptors */
+            $interceptors = $bindings[$methodName];
             $body = sprintf(
                 $template,
+                $this->interceptorShortNames($interceptors),
                 $methodName, // '(string) method' arg
                 $methodName, // bindings key
                 $methodName, // parent::method(...)
@@ -236,6 +241,23 @@ PHP;
         }
 
         $this->insert(implode("\n", $interceptedMethods));
+    }
+
+    /**
+     * Short class names for the always-on weaved-method comment (self-documenting bind).
+     *
+     * @param list<object> $interceptors
+     */
+    private function interceptorShortNames(array $interceptors): string
+    {
+        $names = [];
+        foreach ($interceptors as $interceptor) {
+            $fqn = $interceptor::class;
+            $pos = strrpos($fqn, '\\');
+            $names[] = $pos === false ? $fqn : substr($fqn, $pos + 1);
+        }
+
+        return $names === [] ? '(none)' : implode(', ', $names);
     }
 
     /** @psalm-external-mutation-free */

--- a/tests/AopCodeTest.php
+++ b/tests/AopCodeTest.php
@@ -163,6 +163,8 @@ class AopCodeTest extends TestCase
         $this->assertStringContainsString('function returnTypeVoid(): void', $code);
         $this->assertStringNotContainsString('return $invocation->proceed', $code);
         $this->assertStringContainsString('$invocation->proceed();', $code);
+        // empty interceptor list produces the documented "(none)" comment
+        $this->assertStringContainsString("// (none)", $code);
     }
 
     public function testGeneratedMethodDocumentsInterceptorShortClassNames(): void

--- a/tests/AopCodeTest.php
+++ b/tests/AopCodeTest.php
@@ -165,6 +165,18 @@ class AopCodeTest extends TestCase
         $this->assertStringContainsString('$invocation->proceed();', $code);
     }
 
+    public function testGeneratedMethodDocumentsInterceptorShortClassNames(): void
+    {
+        $bind = new Bind();
+        $bind->bindInterceptors('returnSame', [new FakeDoubleInterceptor(), new NullInterceptor()]);
+        $code = $this->codeGen->generate(new ReflectionClass(FakeMock::class), $bind, '_test');
+
+        // Always-on comment: short class names only (no FQN), bind order preserved
+        $this->assertStringContainsString('// FakeDoubleInterceptor, NullInterceptor', $code);
+        $this->assertStringNotContainsString('// Ray\\Aop\\FakeDoubleInterceptor', $code);
+        $this->assertStringContainsString('$invocation = new \\Ray\\Aop\\ReflectiveMethodInvocation', $code);
+    }
+
     public function testNonVoidReturnTypeMethodHasReturnStatement(): void
     {
         $bind = new Bind();

--- a/tests/AopCodeTest.php
+++ b/tests/AopCodeTest.php
@@ -164,7 +164,7 @@ class AopCodeTest extends TestCase
         $this->assertStringNotContainsString('return $invocation->proceed', $code);
         $this->assertStringContainsString('$invocation->proceed();', $code);
         // empty interceptor list produces the documented "(none)" comment
-        $this->assertStringContainsString("// (none)", $code);
+        $this->assertStringContainsString('// (none)', $code);
     }
 
     public function testGeneratedMethodDocumentsInterceptorShortClassNames(): void


### PR DESCRIPTION
## Summary

Weaved methods now always include a `//` comment listing bound interceptor **short class names** (not FQN), so generated proxies are self-documenting when opened in a debugger or by AI coding tools.

```php
public function returnSame($a)
{
    // FakeDoubleInterceptor, NullInterceptor
    $invocation = new \Ray\Aop\ReflectiveMethodInvocation($this, 'returnSame', func_get_args(), $this->bindings['returnSame'], parent::returnSame(...));
    return $invocation->proceed();
}
```

- **Always on** — no debug flag; runtime cost is zero (comments are not executed)
- **Short names only** — readable local documentation, not a full dependency graph (that stays with Ray.Di module trees)
- **`AopCode::GENERATION` → 6** — existing script dirs regenerate once after upgrade

Depends on #260 (already merged).

## Why not a tree dump in Ray.Aop?

Whole-module binding trees belong in Ray.Di (see ray-di/Ray.Di#313). Ray.Aop’s job here is the **local** story next to the generated method.

## Test plan

- [x] `composer cs`
- [x] `phpunit` (including new `testGeneratedMethodDocumentsInterceptorShortClassNames`)
- [x] PHPStan / Psalm (PHP 8.4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generated/weaved methods now include an always-on documentation comment listing bound interceptor short class names (or `// (none)` when empty).

* **Documentation**
  * Updated the changelog with an Unreleased entry describing the new interceptor comment behavior.

* **Bug Fixes**
  * Preserves the interceptor bind order in the generated method documentation.

* **Tests**
  * Added tests covering short-name rendering, correct order, the `(none)` fallback, and reflective method invocation generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->