### PR TITLE
changelog: set 2.20.0 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [2.20.0] - 2026-07-12
 
 ### Changed
 - Proxy dispatch is now a direct `parent::method(...)` first-class callable (no double dispatch through the proxy); intercepted-call overhead roughly halved. Generated proxies are invalidated via `AopCode::GENERATION` — existing script dirs regenerate once after upgrade (stale files are ignored, not loaded). (#260)


### PR DESCRIPTION
Set the release date for 2.20.0 in CHANGELOG.md.

This PR prepares for the 2.20.0 release which includes:
- Direct FCC dispatch performance improvement (#260)
- Faster weave/newInstance path (#259)
- Self-documenting weaved method comments (#262)
- 100% branch coverage (#258)
- Branch coverage CI workflow (#258)
- Bug fixes (#259, #260, #261)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the changelog with the version 2.20.0 release heading and date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->