### PR TITLE
fix: implements list regex swallows the class body brace

### DIFF
--- a/src/AopCode.php
+++ b/src/AopCode.php
@@ -20,7 +20,6 @@ use function strrpos;
 use function substr;
 use function substr_replace;
 use function token_get_all;
-use function trim;
 
 use const T_CLASS;
 use const T_EXTENDS;
@@ -35,7 +34,7 @@ use const T_STRING;
 final class AopCode
 {
     /** Code generation version — bump on codegen changes to invalidate cached proxies */
-    public const GENERATION = 6;
+    public const GENERATION = 7;
 
     /**
      * Template for direct parent-FCC dispatch (no _intercept, no _isAspect flag).
@@ -171,8 +170,10 @@ PHP;
 
             $isClassSignatureEnds = $inClass && $text === '{';
             if ($isClassSignatureEnds) {
-                // Drop trailing spaces before the class body (PSR2 SpaceBeforeBrace / EndLine)
-                $this->code = rtrim($this->code, " \t");
+                // Drop the source whitespace before the body brace; the trait template
+                // re-adds it as a newline so the brace owns its line whatever the
+                // source style was (PSR2 SpaceBeforeBrace / EndLine).
+                $this->code = rtrim($this->code);
                 $this->resolveInterceptTrait($sourceClass);
 
                 return;
@@ -189,10 +190,13 @@ PHP;
      */
     private function implementsInterface(string $interfaceName): void
     {
-        $pattern = '/(class\s+[\w\s]+extends\s+\w+)(?:\s+implements\s+(.+))?/';
+        $pattern = '/(class\s+[\w\s]+extends\s+\w+)(?:\s+implements\s+([^{]*[^{\s]))?/';
         $this->code = (string) preg_replace_callback($pattern, static function ($matches) use ($interfaceName) {
             if (isset($matches[2])) {
-                return sprintf('%s implements %s, \\%s', rtrim($matches[1]), trim($matches[2]), $interfaceName);
+                // A multi-line list is folded onto the declaration line
+                $interfaces = (string) preg_replace('/\s+/', ' ', $matches[2]);
+
+                return sprintf('%s implements %s, \\%s', rtrim($matches[1]), $interfaces, $interfaceName);
             }
 
             return sprintf('%s implements \\%s', rtrim($matches[0]), $interfaceName);
@@ -265,13 +269,13 @@ PHP;
     private function addInterceptorTrait(): void
     {
         // Blank line after trait use (PSR12.Traits.UseDeclaration)
-        $this->add(sprintf("{\n    use \\%s;\n\n}\n", InterceptTrait::class));
+        $this->add(sprintf("\n{\n    use \\%s;\n\n}\n", InterceptTrait::class));
     }
 
     /** @psalm-external-mutation-free */
     private function addReadOnlyInterceptorTrait(): void
     {
-        $this->add(sprintf("{\n    use \\%s;\n\n}\n", ReadOnlyInterceptTrait::class));
+        $this->add(sprintf("\n{\n    use \\%s;\n\n}\n", ReadOnlyInterceptTrait::class));
     }
 
     /** @psalm-external-mutation-free */

--- a/src/AopCode.php
+++ b/src/AopCode.php
@@ -55,6 +55,11 @@ PHP;
         %s$invocation->proceed();
 PHP;
 
+    private const CLASS_DECLARATION_PATTERN = 'class\s+[\w\s]+extends\s+\w+';
+
+    /** Matches the implements list, ending before the body brace; [^{]*[^{\s] stops at the last interface name */
+    private const IMPLEMENTS_LIST_PATTERN = '[^{]*[^{\s]';
+
     private string $code = '';
     private int $curlyBraceCount = 0;
 
@@ -190,7 +195,7 @@ PHP;
      */
     private function implementsInterface(string $interfaceName): void
     {
-        $pattern = '/(class\s+[\w\s]+extends\s+\w+)(?:\s+implements\s+([^{]*[^{\s]))?/';
+        $pattern = '/(' . self::CLASS_DECLARATION_PATTERN . ')(?:\s+implements\s+(' . self::IMPLEMENTS_LIST_PATTERN . '))?/';
         $this->code = (string) preg_replace_callback($pattern, static function ($matches) use ($interfaceName) {
             if (isset($matches[2])) {
                 // A multi-line list is folded onto the declaration line

--- a/tests/AopCodeTest.php
+++ b/tests/AopCodeTest.php
@@ -204,6 +204,41 @@ class AopCodeTest extends TestCase
         $this->assertStringContainsString('implements FakeNullInterface, \Ray\Aop\FakeNullInterface1, \Ray\Aop\WeavedInterface', $code);
     }
 
+    public function testClassWithSameLineBodyBraceGetsWeavedInterfaceAdded(): void
+    {
+        $bind = new Bind();
+        $bind->bindInterceptors('returnSame', []);
+        $code = $this->codeGen->generate(new ReflectionClass(FakeSameLineBraceClass::class), $bind, '_test');
+
+        // The body brace must not be swallowed into the implements list
+        $this->assertStringContainsString('implements FakeNullInterface, \Ray\Aop\WeavedInterface', $code);
+        $this->assertStringNotContainsString('{,', $code);
+        // Body brace stays on its own line (PSR12), whatever the source style is
+        $this->assertMatchesRegularExpression('/implements FakeNullInterface, \\\\Ray\\\\Aop\\\\WeavedInterface\n\{\n/', $code);
+
+        $tempFile = tempnam(sys_get_temp_dir(), 'tmp_') . '.php';
+        file_put_contents($tempFile, $code);
+        require $tempFile;
+        unlink($tempFile);
+        $this->assertTrue(class_exists('\Ray\Aop\FakeSameLineBraceClass_test'));
+    }
+
+    public function testClassWithMultiLineImplementsKeepsEveryInterface(): void
+    {
+        $bind = new Bind();
+        $bind->bindInterceptors('returnSame', []);
+        $code = $this->codeGen->generate(new ReflectionClass(FakeMultiLineImplementsClass::class), $bind, '_test');
+
+        // The list is folded onto the declaration line, no name is dropped
+        $this->assertStringContainsString('implements FakeNullInterface, FakeNullInterface1, \Ray\Aop\WeavedInterface', $code);
+
+        $tempFile = tempnam(sys_get_temp_dir(), 'tmp_') . '.php';
+        file_put_contents($tempFile, $code);
+        require $tempFile;
+        unlink($tempFile);
+        $this->assertTrue(class_exists('\Ray\Aop\FakeMultiLineImplementsClass_test'));
+    }
+
     public function testClassWithoutImplementsGetsWeavedInterfaceAdded(): void
     {
         $bind = new Bind();

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -93,6 +93,41 @@ class CompilerTest extends TestCase
         $this->assertSame(2, $result);
     }
 
+    /**
+     * PSR-12 puts the body brace on its own line, which is what kept the codegen
+     * regex honest. A source class that puts it on the declaration line used to
+     * compile to a proxy that did not parse (CompilationFailedException).
+     */
+    public function testClassWithSameLineBodyBraceIsWeavedIntoWorkingProxy(): void
+    {
+        $bind = (new Bind())->bind(FakeSameLineBraceClass::class, [$this->doublePointcut()]);
+        $weaved = $this->compiler->newInstance(FakeSameLineBraceClass::class, [], $bind);
+
+        // The source interface survives alongside the weaved marker
+        $this->assertInstanceOf(FakeNullInterface::class, $weaved);
+        $this->assertInstanceOf(WeavedInterface::class, $weaved);
+        $this->assertSame(2, $weaved->returnSame(1));
+    }
+
+    /** A multi-line implements list used to lose every name after the first. */
+    public function testClassWithMultiLineImplementsIsWeavedIntoWorkingProxy(): void
+    {
+        $bind = (new Bind())->bind(FakeMultiLineImplementsClass::class, [$this->doublePointcut()]);
+        $weaved = $this->compiler->newInstance(FakeMultiLineImplementsClass::class, [], $bind);
+
+        $this->assertInstanceOf(FakeNullInterface::class, $weaved);
+        $this->assertInstanceOf(FakeNullInterface1::class, $weaved);
+        $this->assertInstanceOf(WeavedInterface::class, $weaved);
+        $this->assertSame(2, $weaved->returnSame(1));
+    }
+
+    private function doublePointcut(): Pointcut
+    {
+        $matcher = new Matcher();
+
+        return new Pointcut($matcher->any(), $matcher->startsWith('return'), [new FakeDoubleInterceptor()]);
+    }
+
     public function testInheritedMethodsAreIntercepted(): void
     {
         $mock = $this->compiler->newInstance(FakeMockGrandChild::class, [], $this->bind);

--- a/tests/Fake/FakeMultiLineImplementsClass.php
+++ b/tests/Fake/FakeMultiLineImplementsClass.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Aop;
+
+// PSR-12 allows the implements list to be split over several lines.
+class FakeMultiLineImplementsClass implements
+    FakeNullInterface,
+    FakeNullInterface1
+{
+    public function returnSame(int $a): int
+    {
+        return $a;
+    }
+}

--- a/tests/Fake/FakeSameLineBraceClass.php
+++ b/tests/Fake/FakeSameLineBraceClass.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Aop;
+
+// Deliberately not PSR-12: the class body brace is on the declaration line.
+// PSR-12 puts it on the next line, which is why this shape went unnoticed.
+class FakeSameLineBraceClass implements FakeNullInterface { public function returnSame(int $a): int { return $a; } }


### PR DESCRIPTION
## Problem

`AopCode::implementsInterface()` matches the implements list with a greedy, unanchored `(.+)`.

It swallows a same-line body brace:

```php
class X_p extends X implements XInterface{, \Ray\Aop\WeavedInterface
```

and stops at the first newline, dropping the rest of a multi-line list:

```php
class M_p extends M implements IA,, \Ray\Aop\WeavedInterface
    IB
```

Neither parses. `Compiler::compile()` reports it as `CompilationFailedException` — "This is most likely a bug in Ray.Aop".

## Fix

`[^{]*[^{\s]` ends the list on its last interface name instead. `parseClass()` now rtrims all trailing whitespace and the trait template supplies the newline, so the body brace always owns its line. `GENERATION` bumped to invalidate cached proxies.

## Tests

Red first: end-to-end through `Compiler::compile()`, then the generated declaration itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated class formatting when braces appear on the same line.
  * Correctly handles multi-line interface declarations while preserving all implemented interfaces.
  * Ensures generated classes consistently include the required weaving interface.
  * Fixed proxy generation so affected classes load and execute correctly with interceptors.

* **Tests**
  * Added coverage for same-line braces and multi-line interface declarations.
  * Added regression checks confirming interface preservation and expected intercepted results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->